### PR TITLE
feat(loki-microservices): add frontend ingress

### DIFF
--- a/aks/main.tf
+++ b/aks/main.tf
@@ -10,6 +10,7 @@ module "loki-stack" {
   dependency_ids   = var.dependency_ids
 
   distributed_mode = var.distributed_mode
+  ingress          = var.ingress
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/aks/outputs.tf
+++ b/aks/outputs.tf
@@ -2,3 +2,8 @@ output "id" {
   description = "ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place."
   value       = module.loki-stack.id
 }
+
+output "loki_credentials" {
+  value     = module.loki-stack.loki_credentials
+  sensitive = true
+}

--- a/charts/loki-microservice/templates/ingressRoute.yaml
+++ b/charts/loki-microservice/templates/ingressRoute.yaml
@@ -1,0 +1,65 @@
+{{- with .Values.frontendIngress }}
+{{- $hosts := printf "(Host(`%s`))" ( join "`) || Host(`" .hosts ) }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: loki-frontend
+spec:
+  secretName: loki-frontend-tls
+  dnsNames:
+    {{- toYaml .hosts | nindent 4 }}
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: {{ .clusterIssuer }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: loki-frontend
+spec:
+  entryPoints:
+  - websecure
+  routes:
+  - match: {{ printf "(%s)" $hosts | quote }}
+    kind: Rule
+    services:
+    - name: {{ .serviceName }}
+      port: 3100
+    middlewares:
+{{- with .allowedIPs }}
+    - name: ip-whitelist
+{{- end }}
+    - name: basic-auth
+  tls:
+    secretName: loki-frontend-tls
+{{- with .allowedIPs }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: ip-whitelist
+spec:
+  ipWhiteList:
+    sourceRange:
+    {{- range . }}
+      - {{ . | quote }}
+    {{- end }}
+{{- end }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: basic-auth
+spec:
+  basicAuth:
+    secret: basic-auth-creds
+---
+apiVersion: v1
+data:
+  users: {{ .lokiCredentials }}
+kind: Secret
+metadata:
+  name: basic-auth-creds
+{{- end }}

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -10,6 +10,7 @@ module "loki-stack" {
   dependency_ids   = var.dependency_ids
 
   distributed_mode = false
+  ingress          = var.ingress
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -2,3 +2,8 @@ output "id" {
   description = "ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place."
   value       = module.loki-stack.id
 }
+
+output "loki_credentials" {
+  value     = module.loki-stack.loki_credentials
+  sensitive = true
+}

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -10,6 +10,7 @@ module "loki-stack" {
   dependency_ids   = var.dependency_ids
 
   distributed_mode = false
+  ingress          = var.ingress
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/kind/outputs.tf
+++ b/kind/outputs.tf
@@ -1,3 +1,8 @@
 output "id" {
   value = module.loki-stack.id
 }
+
+output "loki_credentials" {
+  value     = module.loki-stack.loki_credentials
+  sensitive = true
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,156 +1,167 @@
 locals {
   fullnameOverride = "loki"
 
-  helm_values = [var.distributed_mode ? {
-    datasourceURL = "http://${local.fullnameOverride}-query-frontend.${var.namespace}:3100"
-    loki-distributed = {
-      fullnameOverride = local.fullnameOverride
-      compactor = {
-        enabled = true
-        persistence = {
+  helm_values = [
+    {
+      frontendIngress = var.ingress != null ? {
+        lokiCredentials = base64encode("loki:${htpasswd_password.loki_password_hash.0.bcrypt}")
+        hosts           = var.ingress.hosts
+        clusterIssuer   = var.ingress.cluster_issuer
+        allowedIPs      = var.ingress.allowed_ips
+        serviceName     = "${local.fullnameOverride}-query-frontend"
+      } : null
+    },
+    var.distributed_mode ? {
+      datasourceURL = "http://${local.fullnameOverride}-query-frontend.${var.namespace}:3100"
+      loki-distributed = {
+        fullnameOverride = local.fullnameOverride
+        compactor = {
           enabled = true
-        }
-      }
-      gateway = {
-        enabled = false
-      }
-      indexGateway = {
-        enabled = true
-        persistence = {
-          enabled = true
-        }
-      }
-      ingester = {
-        persistence = {
-          enabled = true
-          size    = "10Gi"
-        }
-        replicas = 1
-      }
-      loki = {
-        structuredConfig = {
-          ruler = {
-            alertmanager_url = "http://kube-prometheus-stack-alertmanager.kube-prometheus-stack:9093"
+          persistence = {
+            enabled = true
           }
-          chunk_store_config = {
-            chunk_cache_config = {
-              enable_fifocache = false
-              memcached = {
-                expiration = "24h"
-              }
-              memcached_client = {
-                host    = "${local.fullnameOverride}-memcached-chunks.${var.namespace}.svc.cluster.local"
-                service = "http"
-                timeout = "500ms"
-              }
+        }
+        gateway = {
+          enabled = false
+        }
+        indexGateway = {
+          enabled = true
+          persistence = {
+            enabled = true
+          }
+        }
+        ingester = {
+          persistence = {
+            enabled = true
+            size    = "10Gi"
+          }
+          replicas = 1
+        }
+        loki = {
+          structuredConfig = {
+            ruler = {
+              alertmanager_url = "http://kube-prometheus-stack-alertmanager.kube-prometheus-stack:9093"
             }
-          }
-          compactor = {
-            retention_delete_delay = "1h"
-            retention_enabled      = false
-          }
-          ingester = {
-            wal = {
-              replay_memory_ceiling = "500MB"
-            }
-          }
-          limits_config = {
-            ingestion_rate_mb           = 10
-            max_chunks_per_query        = 0
-            max_entries_limit_per_query = 0
-            max_query_length            = "9000h"
-            max_query_parallelism       = 6
-            per_stream_rate_limit       = "10MB"
-            retention_period            = "9000h"
-          }
-          querier = {
-            max_concurrent = 2
-            query_timeout  = "5m"
-          }
-          query_range = {
-            cache_results                 = true
-            max_retries                   = 50
-            parallelise_shardable_queries = false
-            results_cache = {
-              cache = {
+            chunk_store_config = {
+              chunk_cache_config = {
                 enable_fifocache = false
                 memcached = {
                   expiration = "24h"
                 }
                 memcached_client = {
-                  host    = "${local.fullnameOverride}-memcached-frontend.${var.namespace}.svc.cluster.local"
+                  host    = "${local.fullnameOverride}-memcached-chunks.${var.namespace}.svc.cluster.local"
+                  service = "http"
+                  timeout = "500ms"
+                }
+              }
+            }
+            compactor = {
+              retention_delete_delay = "1h"
+              retention_enabled      = false
+            }
+            ingester = {
+              wal = {
+                replay_memory_ceiling = "500MB"
+              }
+            }
+            limits_config = {
+              ingestion_rate_mb           = 10
+              max_chunks_per_query        = 0
+              max_entries_limit_per_query = 0
+              max_query_length            = "9000h"
+              max_query_parallelism       = 6
+              per_stream_rate_limit       = "10MB"
+              retention_period            = "9000h"
+            }
+            querier = {
+              max_concurrent = 2
+              query_timeout  = "5m"
+            }
+            query_range = {
+              cache_results                 = true
+              max_retries                   = 50
+              parallelise_shardable_queries = false
+              results_cache = {
+                cache = {
+                  enable_fifocache = false
+                  memcached = {
+                    expiration = "24h"
+                  }
+                  memcached_client = {
+                    host    = "${local.fullnameOverride}-memcached-frontend.${var.namespace}.svc.cluster.local"
+                    service = "http"
+                    timeout = "500ms"
+                  }
+                }
+              }
+            }
+            server = {
+              grpc_server_max_recv_msg_size = 33554432
+              grpc_server_max_send_msg_size = 33554432
+              http_server_read_timeout      = "180s"
+              http_server_write_timeout     = "180s"
+            }
+            storage_config = {
+              boltdb_shipper = {
+                index_gateway_client = {
+                  log_gateway_requests = true
+                }
+              }
+              index_queries_cache_config = {
+                enable_fifocache = false
+                memcached = {
+                  expiration = "24h"
+                }
+                memcached_client = {
+                  host    = "${local.fullnameOverride}-memcached-index-queries.${var.namespace}.svc.cluster.local"
                   service = "http"
                   timeout = "500ms"
                 }
               }
             }
           }
-          server = {
-            grpc_server_max_recv_msg_size = 33554432
-            grpc_server_max_send_msg_size = 33554432
-            http_server_read_timeout      = "180s"
-            http_server_write_timeout     = "180s"
-          }
-          storage_config = {
-            boltdb_shipper = {
-              index_gateway_client = {
-                log_gateway_requests = true
-              }
-            }
-            index_queries_cache_config = {
-              enable_fifocache = false
-              memcached = {
-                expiration = "24h"
-              }
-              memcached_client = {
-                host    = "${local.fullnameOverride}-memcached-index-queries.${var.namespace}.svc.cluster.local"
-                service = "http"
-                timeout = "500ms"
-              }
-            }
-          }
         }
-      }
-      memcachedChunks = {
-        enabled = true
-      }
-      memcachedFrontend = {
-        enabled = true
-      }
-      memcachedIndexQueries = {
-        enabled = true
-      }
-      querier = {
-        affinity = ""
-        replicas = 4
-      }
-      ruler = {
-        directories = {}
-        enabled     = false
-      }
-    }
-    promtail = {
-      config = {
-        clients = [{
-          url = "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push"
-        }]
-      }
-    }
-    } : null, var.distributed_mode ? null : {
-    loki-stack = {
-      loki = {
-        serviceName = "loki-stack.loki-stack"
-        serviceMonitor = {
+        memcachedChunks = {
           enabled = true
+        }
+        memcachedFrontend = {
+          enabled = true
+        }
+        memcachedIndexQueries = {
+          enabled = true
+        }
+        querier = {
+          affinity = ""
+          replicas = 4
+        }
+        ruler = {
+          directories = {}
+          enabled     = false
         }
       }
       promtail = {
-        serviceMonitor = {
-          enabled = true
+        config = {
+          clients = [{
+            url = "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push"
+          }]
         }
-        # TODO check next block's indentation
-        filebeat = {
-          extraContainers = <<-EOT
+      }
+    } : null,
+    var.distributed_mode ? null : {
+      loki-stack = {
+        loki = {
+          serviceName = "loki-stack.loki-stack"
+          serviceMonitor = {
+            enabled = true
+          }
+        }
+        promtail = {
+          serviceMonitor = {
+            enabled = true
+          }
+          # TODO check next block's indentation
+          filebeat = {
+            extraContainers = <<-EOT
           - name: filebeat-prometheus-exporter
             image: "trustpilot/beat-exporter:0.4.0"
             ports:
@@ -158,8 +169,9 @@ locals {
               protocol: TCP
               name: metrics
         EOT
+          }
         }
       }
     }
-  }]
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,16 @@ resource "null_resource" "dependencies" {
   triggers = var.dependency_ids
 }
 
+resource "random_password" "loki_password" {
+  count  = var.ingress != null ? 1 : 0
+  length = 30
+}
+
+resource "htpasswd_password" "loki_password_hash" {
+  count    = var.ingress != null ? 1 : 0
+  password = random_password.loki_password.0.result
+}
+
 resource "argocd_project" "this" {
   metadata {
     name      = "loki-stack"

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,12 @@
+output "id" {
+  description = "ID to pass other modules in order to refer to this module as a dependency."
+  value       = resource.null_resource.this.id
+}
+
+output "loki_credentials" {
+  value = var.ingress != null ? {
+    username = "loki"
+    password = random_password.loki_password.0.result
+  } : null
+  sensitive = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,0 @@
-output "id" {
-  description = "ID to pass other modules in order to refer to this module as a dependency."
-  value       = resource.null_resource.this.id
-}

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,13 @@ variable "distributed_mode" {
   type        = bool
   default     = false
 }
+
+variable "ingress" {
+  description = "Loki frontend ingress configuration"
+  type = object({
+    hosts          = list(string)
+    cluster_issuer = string
+    allowed_ips    = optional(list(string), [])
+  })
+  default = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,8 @@ terraform {
     utils = {
       source = "cloudposse/utils"
     }
+    htpasswd = {
+      source = "loafoe/htpasswd"
+    }
   }
 }


### PR DESCRIPTION
Loki query frontend ingress for log exports using LogCLI.
To activate, set `ingress` variable as follows:
```hcl
module "loki-stack" {
  ...
  # ingress is supported only in distributed mode
  distributed_mode = true

  ingress = {
    cluster_issuer = string, required
    hosts          = list(string), required
    allowed_ips    = list(string), optional, default: empty list
  }
  ...
}
```
Basic authentication is enabled when using LogCLI and credentials can be recovered using the following output:
```hcl
output "loki_credentials" {
  value     = module.loki-stack.loki_credentials
  sensitive = true
}
```