### PR TITLE
feat(loki-microservices): flush ingester chunks on shutdown

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -150,7 +150,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.9"`
+Default: `"v1.0.0-alpha.10"`
 
 === Outputs
 
@@ -291,7 +291,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.9"`
+|`"v1.0.0-alpha.10"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -153,7 +153,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.9"`
+Default: `"v1.0.0-alpha.10"`
 
 === Outputs
 
@@ -292,7 +292,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.9"`
+|`"v1.0.0-alpha.10"`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -153,7 +153,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.9"`
+Default: `"v1.0.0-alpha.10"`
 
 === Outputs
 
@@ -292,7 +292,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.9"`
+|`"v1.0.0-alpha.10"`
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -154,7 +154,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.9"`
+Default: `"v1.0.0-alpha.10"`
 
 === Outputs
 
@@ -294,7 +294,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.9"`
+|`"v1.0.0-alpha.10"`
 |no
 
 |===

--- a/locals.tf
+++ b/locals.tf
@@ -62,6 +62,7 @@ locals {
             ingester = {
               wal = {
                 replay_memory_ceiling = "500MB"
+                flush_on_shutdown     = true
               }
             }
             limits_config = {


### PR DESCRIPTION
**Summary**
Loki Ingester in-memory chunks are flushed on shutdown to avoid data loss when changing storage config (Ingester restart).
Example of storage config change: Blue/Green setup with active/idle storage.

**Test platform**
- [x] Azure
- [ ] AWS
- [x] KIND