### PR TITLE
fix: hide sensitive values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,10 +27,6 @@ The following providers are used by this module:
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
-=== Modules
-
-No modules.
-
 === Resources
 
 The following resources are used by this module:
@@ -43,9 +39,6 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/random/latest/docs/resources/password[random_password.loki_password] (resource)
 - https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] (data source)
 
-=== Required Inputs
-
-No required inputs.
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -154,13 +147,21 @@ Type: `string`
 
 Default: `"loki-stack"`
 
+==== [[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+
+Description: n/a
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.12"`
+Default: `"v1.0.0-alpha.13"`
 
 === Outputs
 
@@ -308,10 +309,16 @@ object({
 |`"loki-stack"`
 |no
 
+|[[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+|n/a
+|`map(string)`
+|`{}`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.12"`
+|`"v1.0.0-alpha.13"`
 |no
 
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -147,7 +147,7 @@ Type: `string`
 
 Default: `"loki-stack"`
 
-==== [[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+==== [[input_sensitive_helm_values]] <<input_sensitive_helm_values,sensitive_helm_values>>
 
 Description: n/a
 
@@ -309,7 +309,7 @@ object({
 |`"loki-stack"`
 |no
 
-|[[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+|[[input_sensitive_helm_values]] <<input_sensitive_helm_values,sensitive_helm_values>>
 |n/a
 |`map(string)`
 |`{}`

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -149,7 +149,7 @@ Type: `string`
 
 Default: `"loki-stack"`
 
-==== [[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+==== [[input_sensitive_helm_values]] <<input_sensitive_helm_values,sensitive_helm_values>>
 
 Description: n/a
 
@@ -309,7 +309,7 @@ object({
 |`"loki-stack"`
 |no
 
-|[[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+|[[input_sensitive_helm_values]] <<input_sensitive_helm_values,sensitive_helm_values>>
 |n/a
 |`map(string)`
 |`{}`

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -13,10 +13,6 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
-=== Providers
-
-No providers.
-
 === Modules
 
 The following Modules are called:
@@ -26,10 +22,6 @@ The following Modules are called:
 Source: ../
 
 Version:
-
-=== Resources
-
-No resources.
 
 === Required Inputs
 
@@ -157,13 +149,21 @@ Type: `string`
 
 Default: `"loki-stack"`
 
+==== [[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+
+Description: n/a
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.12"`
+Default: `"v1.0.0-alpha.13"`
 
 === Outputs
 
@@ -309,10 +309,16 @@ object({
 |`"loki-stack"`
 |no
 
+|[[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+|n/a
+|`map(string)`
+|`{}`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.12"`
+|`"v1.0.0-alpha.13"`
 |no
 
 |===

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -5,5 +5,4 @@ variable "logs_storage" {
     storage_account     = string
     storage_account_key = string
   })
-  sensitive = true
 }

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -42,7 +42,6 @@ locals {
     azure = {
       container_name  = var.logs_storage.container
       account_name    = var.logs_storage.storage_account
-      account_key     = var.logs_storage.storage_account_key
       request_timeout = "180s"
       max_retries     = 50
       min_retry_delay = "1s"

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -13,11 +13,11 @@ module "loki-stack" {
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat
 
-  sensitive_values = merge(var.distributed_mode ? {
+  sensitive_helm_values = merge(var.distributed_mode ? {
     "loki-distributed.loki.storageConfig.azure.account_key" = var.logs_storage.storage_account_key
     } : {
     "loki-stack.loki.config.storage_config.azure.account_key" = var.logs_storage.storage_account_key
-  }, var.sensitive_values)
+  }, var.sensitive_helm_values)
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -13,5 +13,11 @@ module "loki-stack" {
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat
 
+  sensitive_values = merge(var.distributed_mode ? {
+    "loki-distributed.loki.storageConfig.azure.account_key" = var.logs_storage.storage_account_key
+    } : {
+    "loki-stack.loki.config.storage_config.azure.account_key" = var.logs_storage.storage_account_key
+  }, var.sensitive_values)
+
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -149,7 +149,7 @@ Type: `string`
 
 Default: `"loki-stack"`
 
-==== [[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+==== [[input_sensitive_helm_values]] <<input_sensitive_helm_values,sensitive_helm_values>>
 
 Description: n/a
 
@@ -309,7 +309,7 @@ object({
 |`"loki-stack"`
 |no
 
-|[[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+|[[input_sensitive_helm_values]] <<input_sensitive_helm_values,sensitive_helm_values>>
 |n/a
 |`map(string)`
 |`{}`

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -13,10 +13,6 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
-=== Providers
-
-No providers.
-
 === Modules
 
 The following Modules are called:
@@ -26,10 +22,6 @@ The following Modules are called:
 Source: ../
 
 Version:
-
-=== Resources
-
-No resources.
 
 === Required Inputs
 
@@ -157,13 +149,21 @@ Type: `string`
 
 Default: `"loki-stack"`
 
+==== [[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+
+Description: n/a
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.12"`
+Default: `"v1.0.0-alpha.13"`
 
 === Outputs
 
@@ -309,10 +309,16 @@ object({
 |`"loki-stack"`
 |no
 
+|[[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+|n/a
+|`map(string)`
+|`{}`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.12"`
+|`"v1.0.0-alpha.13"`
 |no
 
 |===

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -13,7 +13,7 @@ module "loki-stack" {
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat
 
-  sensitive_values = merge({}, var.sensitive_values)
+  sensitive_helm_values = merge({}, var.sensitive_helm_values)
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -13,5 +13,7 @@ module "loki-stack" {
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat
 
+  sensitive_values = merge({}, var.sensitive_values)
+
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -13,10 +13,6 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
-=== Providers
-
-No providers.
-
 === Modules
 
 The following Modules are called:
@@ -26,10 +22,6 @@ The following Modules are called:
 Source: ../
 
 Version:
-
-=== Resources
-
-No resources.
 
 === Required Inputs
 
@@ -158,13 +150,21 @@ Type: `string`
 
 Default: `"loki-stack"`
 
+==== [[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+
+Description: n/a
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.12"`
+Default: `"v1.0.0-alpha.13"`
 
 === Outputs
 
@@ -311,10 +311,16 @@ object({
 |`"loki-stack"`
 |no
 
+|[[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+|n/a
+|`map(string)`
+|`{}`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.12"`
+|`"v1.0.0-alpha.13"`
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -150,7 +150,7 @@ Type: `string`
 
 Default: `"loki-stack"`
 
-==== [[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+==== [[input_sensitive_helm_values]] <<input_sensitive_helm_values,sensitive_helm_values>>
 
 Description: n/a
 
@@ -311,7 +311,7 @@ object({
 |`"loki-stack"`
 |no
 
-|[[input_sensitive_values]] <<input_sensitive_values,sensitive_values>>
+|[[input_sensitive_helm_values]] <<input_sensitive_helm_values,sensitive_helm_values>>
 |n/a
 |`map(string)`
 |`{}`

--- a/kind/locals.tf
+++ b/kind/locals.tf
@@ -49,12 +49,11 @@ locals {
 
   storage_config = {
     aws = {
-      bucketnames       = "${var.logs_storage.bucket_name}"
-      endpoint          = "${var.logs_storage.endpoint}"
-      access_key_id     = "${var.logs_storage.access_key}"
-      secret_access_key = "${var.logs_storage.secret_access_key}"
-      s3forcepathstyle  = true
-      insecure          = true
+      bucketnames      = "${var.logs_storage.bucket_name}"
+      endpoint         = "${var.logs_storage.endpoint}"
+      access_key_id    = "${var.logs_storage.access_key}"
+      s3forcepathstyle = true
+      insecure         = true
     }
     boltdb_shipper = {
       shared_store = "aws"

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -13,5 +13,11 @@ module "loki-stack" {
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat
 
+  sensitive_values = merge(var.distributed_mode ? {
+    "loki-distributed.loki.storageConfig.aws.secret_access_key" = var.logs_storage.secret_access_key
+    } : {
+    "loki-stack.loki.config.storage_config.aws.secret_access_key" = var.logs_storage.secret_access_key
+  }, var.sensitive_values)
+
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -13,11 +13,11 @@ module "loki-stack" {
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat
 
-  sensitive_values = merge(var.distributed_mode ? {
+  sensitive_helm_values = merge(var.distributed_mode ? {
     "loki-distributed.loki.storageConfig.aws.secret_access_key" = var.logs_storage.secret_access_key
     } : {
     "loki-stack.loki.config.storage_config.aws.secret_access_key" = var.logs_storage.secret_access_key
-  }, var.sensitive_values)
+  }, var.sensitive_helm_values)
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,13 @@ resource "argocd_application" "this" {
       path            = format("charts/%s", var.distributed_mode ? "loki-microservice" : "loki-stack")
       target_revision = var.target_revision
       helm {
+        dynamic "parameter" {
+          for_each = var.sensitive_values
+          content {
+            name  = parameter.key
+            value = sensitive(parameter.value)
+          }
+        }
         values = data.utils_deep_merge_yaml.values.output
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "argocd_application" "this" {
       target_revision = var.target_revision
       helm {
         dynamic "parameter" {
-          for_each = var.sensitive_values
+          for_each = var.sensitive_helm_values
           content {
             name  = parameter.key
             value = sensitive(parameter.value)

--- a/variables.tf
+++ b/variables.tf
@@ -82,3 +82,8 @@ variable "enable_filebeat" {
   type    = bool
   default = false
 }
+
+variable "sensitive_values" {
+  type    = map(string)
+  default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -83,7 +83,7 @@ variable "enable_filebeat" {
   default = false
 }
 
-variable "sensitive_values" {
+variable "sensitive_helm_values" {
   type    = map(string)
   default = {}
 }


### PR DESCRIPTION
**Summary**
`utils_deep_merge_yaml` data source used in _main.tf_ of the root module outputs in clear text values that are marked sensitive. With this PR, sensitive values are passed to root module and submodule via the `sensitive_values` variable therefore no longer included in the deep merge.

**Test platform**
- [x] Azure
- [ ] AWS
- [x] KIND