### PR TITLE
feat(azure)!: use managed identity to access object storage

### DIFF
--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -13,6 +13,12 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
+=== Providers
+
+The following providers are used by this module:
+
+- [[provider_azurerm]] <<provider_azurerm,azurerm>>
+
 === Modules
 
 The following Modules are called:
@@ -23,21 +29,33 @@ Source: ../
 
 Version:
 
+=== Resources
+
+The following resources are used by this module:
+
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential[azurerm_federated_identity_credential.loki] (resource)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.contributor] (resource)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.loki] (resource)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node] (data source)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] (data source)
+
 === Required Inputs
 
 The following input variables are required:
 
 ==== [[input_logs_storage]] <<input_logs_storage,logs_storage>>
 
-Description: Azure Log storage configuration
+Description: Azure Blob Storage configuration for logs persistence.
 
 Type:
 [source,hcl]
 ----
 object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container                        = string
+    storage_account                  = string
+    managed_identity_node_rg_name    = optional(string, null)
+    managed_identity_oidc_issuer_url = optional(string, null)
+    storage_account_key              = optional(string, null)
   })
 ----
 
@@ -182,12 +200,32 @@ Description: n/a
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
+= Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_azurerm]] <<provider_azurerm,azurerm>> |n/a
+|===
+
 = Modules
 
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
 |[[module_loki-stack]] <<module_loki-stack,loki-stack>> |../ |
+|===
+
+= Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential[azurerm_federated_identity_credential.loki] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.contributor] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.loki] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] |data source
 |===
 
 = Inputs
@@ -280,15 +318,17 @@ object({
 |no
 
 |[[input_logs_storage]] <<input_logs_storage,logs_storage>>
-|Azure Log storage configuration
+|Azure Blob Storage configuration for logs persistence.
 |
 
 [source]
 ----
 object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container                        = string
+    storage_account                  = string
+    managed_identity_node_rg_name    = optional(string, null)
+    managed_identity_oidc_issuer_url = optional(string, null)
+    storage_account_key              = optional(string, null)
   })
 ----
 

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -1,9 +1,20 @@
 variable "logs_storage" {
-  description = "Azure Log storage configuration"
+  description = "Azure Blob Storage configuration for logs persistence."
   type = object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container                        = string
+    storage_account                  = string
+    managed_identity_node_rg_name    = optional(string, null)
+    managed_identity_oidc_issuer_url = optional(string, null)
+    storage_account_key              = optional(string, null)
   })
-  sensitive = true
+
+  validation {
+    condition     = (var.logs_storage.managed_identity_node_rg_name == null) != (var.logs_storage.storage_account_key == null)
+    error_message = "You must set one (and only one) of these attributes: managed_identity_node_rg_name, storage_account_key."
+  }
+
+  validation {
+    condition     = (var.logs_storage.managed_identity_node_rg_name == null) == (var.logs_storage.managed_identity_oidc_issuer_url == null)
+    error_message = "managed_identity_node_rg_name & managed_identity_oidc_issuer_url are (un)set together."
+  }
 }

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -1,7 +1,24 @@
 locals {
+  use_managed_identity = var.logs_storage.managed_identity_node_rg_name != null
+
   helm_values = [var.distributed_mode ? {
-    loki-distributed = {
-      loki = {
+    loki-distributed = merge(local.use_managed_identity ? {
+      serviceAccount = {
+        annotations = {
+          "azure.workload.identity/client-id" = azurerm_user_assigned_identity.loki[0].client_id
+        }
+      }
+      } : null, {
+      loki = merge(local.use_managed_identity ? {
+        # version >= 2.8 is required for workload identity support. Current chart version uses loki 2.7.5.
+        # TODO remove once chart uses a version >= 2.8.
+        image = {
+          tag = "2.8.0"
+        }
+        podLabels = {
+          "azure.workload.identity/use" = "true"
+        }
+        } : null, {
         schemaConfig  = local.schema_config
         storageConfig = local.storage_config
         structuredConfig = {
@@ -10,18 +27,33 @@ locals {
             working_directory = "/var/loki"
           }
         }
-      }
-    }
+      })
+    })
     } : null, var.distributed_mode ? null : {
     loki-stack = {
-      loki = {
+      loki = merge(local.use_managed_identity ? {
+        # Current chart version uses loki 2.6.1.
+        # TODO remove once chart uses a version >= 2.8.
+        image = {
+          tag = "2.8.0"
+        }
+        serviceAccount = {
+          annotations = {
+            "azure.workload.identity/client-id" = azurerm_user_assigned_identity.loki[0].client_id
+          }
+        }
+        podLabels = {
+          "azure.workload.identity/use" = "true"
+        }
+        } : null, {
         config = {
           schema_config  = local.schema_config
           storage_config = local.storage_config
         }
-      }
+      })
     }
-  }]
+    }
+  ]
 
   schema_config = {
     configs = [
@@ -39,15 +71,17 @@ locals {
   }
 
   storage_config = {
-    azure = {
-      container_name  = var.logs_storage.container
-      account_name    = var.logs_storage.storage_account
-      account_key     = var.logs_storage.storage_account_key
-      request_timeout = "180s"
-      max_retries     = 50
-      min_retry_delay = "1s"
-      max_retry_delay = "5s"
-    }
+    azure = merge(local.use_managed_identity ? null : {
+      account_key = var.logs_storage.storage_account_key
+      }, {
+      use_federated_token = local.use_managed_identity
+      container_name      = var.logs_storage.container
+      account_name        = var.logs_storage.storage_account
+      request_timeout     = "180s"
+      max_retries         = 50
+      min_retry_delay     = "1s"
+      max_retry_delay     = "5s"
+    })
     boltdb_shipper = {
       shared_store = "azure"
     }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,3 +1,43 @@
+data "azurerm_resource_group" "node" {
+  count = local.use_managed_identity ? 1 : 0
+
+  name = var.logs_storage.managed_identity_node_rg_name
+}
+
+data "azurerm_storage_container" "container" {
+  count = local.use_managed_identity ? 1 : 0
+
+  name                 = var.logs_storage.container
+  storage_account_name = var.logs_storage.storage_account
+}
+
+resource "azurerm_user_assigned_identity" "loki" {
+  count = local.use_managed_identity ? 1 : 0
+
+  resource_group_name = data.azurerm_resource_group.node[0].name
+  location            = data.azurerm_resource_group.node[0].location
+  name                = "loki"
+}
+
+resource "azurerm_role_assignment" "contributor" {
+  count = local.use_managed_identity ? 1 : 0
+
+  scope                = data.azurerm_storage_container.container[0].resource_manager_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.loki[0].principal_id
+}
+
+resource "azurerm_federated_identity_credential" "loki" {
+  count = local.use_managed_identity ? 1 : 0
+
+  name                = "loki"
+  resource_group_name = data.azurerm_resource_group.node[0].name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = var.logs_storage.managed_identity_oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.loki[0].id
+  subject             = "system:serviceaccount:${var.namespace}:loki" # "loki" is the fullnameOverride value
+}
+
 module "loki-stack" {
   source = "../"
 

--- a/locals.tf
+++ b/locals.tf
@@ -5,7 +5,7 @@ locals {
     {
       eventHandler = {
         namespace = var.namespace
-        lokiURL   = var.distributed_mode ? "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push" : "http://loki-stack.${var.namespace}:3100/loki/api/v1/push"
+        lokiURL   = var.distributed_mode ? "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push" : "http://${local.fullnameOverride}.${var.namespace}:3100/loki/api/v1/push"
         labels    = {}
       }
     },
@@ -172,13 +172,21 @@ locals {
     var.distributed_mode ? null : {
       loki-stack = {
         loki = {
-          serviceName = "loki-stack.${var.namespace}"
+          fullnameOverride = local.fullnameOverride
+          serviceName      = "${local.fullnameOverride}.${var.namespace}"
           # TODO serviceMonitor is a KPS CRD, manage this circular dependency
           serviceMonitor = {
             enabled = true
           }
         }
         promtail = {
+          config = {
+            clients = [
+              {
+                url = "http://${local.fullnameOverride}:3100/loki/api/v1/push"
+              }
+            ]
+          }
           # Same previous comment
           serviceMonitor = {
             enabled = true


### PR DESCRIPTION
:warning: **Breaking change**

**Summary**
User can now choose between key-based and identity-based access to object storage.
The variable `logs_storage` is refactored as follow:
```hcl
logs_storage = {
  container       = azurerm_storage_container.logs.name
  storage_account = azurerm_storage_account.logs.name

  managed_identity_node_rg_name = module.cluster.node_resource_group # Unset when using account key.
  managed_identity_oidc_issuer_url = module.cluster.oidc_issuer_url # Unset when using account key.

  storage_account_key = azurerm_storage_account.logs.primary_access_key # Unset when using a managed identity
}
```
**Imporant:** when using identity-based access, [azure-workload-identity](https://github.com/camptocamp/devops-stack-module-azure-workload-identity) must be declared as module dependency.

**Test platform**
- [x] Azure
- [ ] AWS
- [ ] KIND