### PR TITLE
feat: ship k8s events to Loki

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -153,7 +153,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.13"`
+Default: `"v1.0.0"`
 
 === Outputs
 
@@ -304,7 +304,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.13"`
+|`"v1.0.0"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -155,7 +155,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.13"`
+Default: `"v1.0.0"`
 
 === Outputs
 
@@ -304,7 +304,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.13"`
+|`"v1.0.0"`
 |no
 
 |===

--- a/charts/loki-microservice/templates/event_handler.yaml
+++ b/charts/loki-microservice/templates/event_handler.yaml
@@ -1,0 +1,121 @@
+{{- with .Values.eventHandler }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent-eventhandler
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent-eventhandler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent-eventhandler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent-eventhandler
+subjects:
+- kind: ServiceAccount
+  name: grafana-agent-eventhandler
+  namespace: {{ .namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent-eventhandler-svc
+spec:
+  ports:
+  - port: 12345
+    name: http-metrics
+  clusterIP: None
+  selector:
+    name: grafana-agent-eventhandler
+---
+kind: ConfigMap
+metadata:
+  name: grafana-agent-eventhandler
+apiVersion: v1
+data:
+  agent.yaml: |
+    server:
+      log_level: info
+
+    integrations:
+      eventhandler:
+        cache_path: "/etc/eventhandler/eventhandler.cache"
+
+    logs:
+      configs:
+      - name: default
+        clients:
+        - url: {{ .lokiURL }}
+          external_labels:
+            {{- toYaml .labels | nindent 12 }}
+        positions:
+          filename: /tmp/positions0.yaml
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: grafana-agent-eventhandler
+spec:
+  serviceName: "grafana-agent-eventhandler-svc"
+  selector:
+    matchLabels:
+      name: grafana-agent-eventhandler
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: grafana-agent-eventhandler
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: agent
+        image: grafana/agent:main
+        imagePullPolicy: IfNotPresent
+        args:
+        - -config.file=/etc/agent/agent.yaml
+        - -enable-features=integrations-next
+        - -server.http.address=0.0.0.0:12345
+        command:
+        - /bin/agent
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        volumeMounts:
+        - name: grafana-agent
+          mountPath: /etc/agent
+        - name: eventhandler-cache
+          mountPath: /etc/eventhandler
+      serviceAccount: grafana-agent-eventhandler
+      volumes:
+        - configMap:
+            name: grafana-agent-eventhandler
+          name: grafana-agent
+  volumeClaimTemplates:
+  - metadata:
+      name: eventhandler-cache
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+{{- end }}

--- a/charts/loki-stack/templates/event_handler.yaml
+++ b/charts/loki-stack/templates/event_handler.yaml
@@ -1,0 +1,121 @@
+{{- with .Values.eventHandler }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent-eventhandler
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent-eventhandler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent-eventhandler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent-eventhandler
+subjects:
+- kind: ServiceAccount
+  name: grafana-agent-eventhandler
+  namespace: {{ .namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent-eventhandler-svc
+spec:
+  ports:
+  - port: 12345
+    name: http-metrics
+  clusterIP: None
+  selector:
+    name: grafana-agent-eventhandler
+---
+kind: ConfigMap
+metadata:
+  name: grafana-agent-eventhandler
+apiVersion: v1
+data:
+  agent.yaml: |
+    server:
+      log_level: info
+
+    integrations:
+      eventhandler:
+        cache_path: "/etc/eventhandler/eventhandler.cache"
+
+    logs:
+      configs:
+      - name: default
+        clients:
+        - url: {{ .lokiURL }}
+          external_labels:
+            {{- toYaml .labels | nindent 12 }}
+        positions:
+          filename: /tmp/positions0.yaml
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: grafana-agent-eventhandler
+spec:
+  serviceName: "grafana-agent-eventhandler-svc"
+  selector:
+    matchLabels:
+      name: grafana-agent-eventhandler
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: grafana-agent-eventhandler
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: agent
+        image: grafana/agent:main
+        imagePullPolicy: IfNotPresent
+        args:
+        - -config.file=/etc/agent/agent.yaml
+        - -enable-features=integrations-next
+        - -server.http.address=0.0.0.0:12345
+        command:
+        - /bin/agent
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        volumeMounts:
+        - name: grafana-agent
+          mountPath: /etc/agent
+        - name: eventhandler-cache
+          mountPath: /etc/eventhandler
+      serviceAccount: grafana-agent-eventhandler
+      volumes:
+        - configMap:
+            name: grafana-agent-eventhandler
+          name: grafana-agent
+  volumeClaimTemplates:
+  - metadata:
+      name: eventhandler-cache
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+{{- end }}

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -155,7 +155,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.13"`
+Default: `"v1.0.0"`
 
 === Outputs
 
@@ -304,7 +304,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.13"`
+|`"v1.0.0"`
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -156,7 +156,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.13"`
+Default: `"v1.0.0"`
 
 === Outputs
 
@@ -306,7 +306,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.13"`
+|`"v1.0.0"`
 |no
 
 |===

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,7 @@
 ## Standard variables
 #######################
 
+# Useless cluster_name & base_domain variables ? TODO remove if it's the case.
 variable "cluster_name" {
   description = "Name given to the cluster. Value used for the ingress' URL of the application."
   type        = string


### PR DESCRIPTION
## Description of the changes

Kubernetes events are useful during workload debugging but they expire after 60 minutes. This PR uses [Grafana Agent integration eventhandler](https://grafana.com/docs/agent/latest/configuration/integrations/integrations-next/eventhandler-config/#eventhandler_config) to ship events to Loki for persistence.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [x] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)