### PR TITLE
fix(azure): storage account key support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -24,8 +26,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -73,14 +73,16 @@ locals {
   storage_config = {
     azure = merge(local.use_managed_identity ? null : {
       account_key = var.logs_storage.storage_account_key
-      }, {
-      use_federated_token = local.use_managed_identity
-      container_name      = var.logs_storage.container
-      account_name        = var.logs_storage.storage_account
-      request_timeout     = "180s"
-      max_retries         = 50
-      min_retry_delay     = "1s"
-      max_retry_delay     = "5s"
+      }, local.use_managed_identity ? {
+      use_federated_token = true
+      } : null,
+      {
+        container_name  = var.logs_storage.container
+        account_name    = var.logs_storage.storage_account
+        request_timeout = "180s"
+        max_retries     = 50
+        min_retry_delay = "1s"
+        max_retry_delay = "5s"
     })
     boltdb_shipper = {
       shared_store = "azure"


### PR DESCRIPTION
## Description of the changes

This PR fixes the error introduced by release 2.0.0 that breaks Loki setup with storage account key. The cause of the error is setting `use_federated_token` storage config parameter when using storage account key while it isn't supported for versions prior to 2.8.
The parameter is now only set when using a managed identity.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s))
- [ ] Yes (in the module itself)

## Tests executed on which distribution(s)

- [ ] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)