### PR TITLE
fix(loki-stack): set Loki datasource isDefault to false

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -153,7 +153,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v2.0.0"`
 
 === Outputs
 
@@ -304,7 +304,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v2.0.0"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -173,7 +173,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v2.0.0"`
 
 === Outputs
 
@@ -344,7 +344,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v2.0.0"`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -155,7 +155,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v2.0.0"`
 
 === Outputs
 
@@ -304,7 +304,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v2.0.0"`
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -156,7 +156,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.0"`
+Default: `"v2.0.0"`
 
 === Outputs
 
@@ -306,7 +306,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.0"`
+|`"v2.0.0"`
 |no
 
 |===

--- a/locals.tf
+++ b/locals.tf
@@ -178,6 +178,7 @@ locals {
           serviceMonitor = {
             enabled = true
           }
+          isDefault = false
         }
         promtail = {
           config = {


### PR DESCRIPTION
## Description of the changes

Prometheus datasource is default and when Loki datasource is also set as default, it doesn't appear in Grafana. This PR fixes this issue for `loki-stack` deployments. Grafana restart is needed so the sidecar picks the new datasource.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s))
- [ ] Yes (in the module itself)

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)