### PR TITLE
fix: grafana agent static tag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -26,6 +24,8 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -185,11 +185,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -185,11 +185,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/charts/loki-microservice/templates/event_handler.yaml
+++ b/charts/loki-microservice/templates/event_handler.yaml
@@ -84,7 +84,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: agent
-        image: grafana/agent:main
+        image: grafana/agent:{{ .grafanaAgentTag }}
         imagePullPolicy: IfNotPresent
         args:
         - -config.file=/etc/agent/agent.yaml

--- a/locals.tf
+++ b/locals.tf
@@ -4,9 +4,9 @@ locals {
   helm_values = [
     {
       eventHandler = {
-        namespace = var.namespace
-        lokiURL   = var.distributed_mode ? "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push" : "http://${local.fullnameOverride}.${var.namespace}:3100/loki/api/v1/push"
-        labels    = {}
+        namespace       = var.namespace
+        lokiURL         = var.distributed_mode ? "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push" : "http://${local.fullnameOverride}.${var.namespace}:3100/loki/api/v1/push"
+        labels          = {}
         grafanaAgentTag = "main-4f86002"
       }
     },

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,7 @@ locals {
         namespace = var.namespace
         lokiURL   = var.distributed_mode ? "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push" : "http://${local.fullnameOverride}.${var.namespace}:3100/loki/api/v1/push"
         labels    = {}
+        grafanaAgentTag = "main-4f86002"
       }
     },
     {


### PR DESCRIPTION
## Description of the changes

Added a fixed Grafana agent tag in order to avoid disruption. Reminder: Grafana agent ships K8s events to Loki

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s))
- [ ] Yes (in the module itself)

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)