### PR TITLE
fix(loki-stack): set static Grafana agent tag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.1"`
+Default: `"v2.0.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -185,11 +185,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -232,7 +232,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.1"`
+|`"v2.0.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -93,7 +93,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.1"`
+Default: `"v2.0.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -272,7 +272,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.1"`
+|`"v2.0.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/charts/loki-stack/templates/event_handler.yaml
+++ b/charts/loki-stack/templates/event_handler.yaml
@@ -84,7 +84,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: agent
-        image: grafana/agent:main
+        image: grafana/agent:{{ .grafanaAgentTag }}
         imagePullPolicy: IfNotPresent
         args:
         - -config.file=/etc/agent/agent.yaml

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.1"`
+Default: `"v2.0.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -232,7 +232,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.1"`
+|`"v2.0.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -76,7 +76,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.1"`
+Default: `"v2.0.2"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -234,7 +234,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.1"`
+|`"v2.0.2"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>


### PR DESCRIPTION
## Description of the changes

Following #52, this PR set a static tag for the monolithic version of loki.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s))
- [ ] Yes (in the module itself)

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)