### PR TITLE
fix: adding more replicas for ingester

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -24,8 +26,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 

--- a/locals.tf
+++ b/locals.tf
@@ -43,7 +43,7 @@ locals {
           persistence = {
             enabled = true
           }
-          replicas = 1
+          replicas = 3
         }
         loki = {
           structuredConfig = {


### PR DESCRIPTION
## Description of the changes
The current distributed Loki deploys a single replica of the ingester component. This can lead to log write interruptions and potential data loss during rollouts and restarts, so I changed the replicas to 3 to avoid data loss.

## Breaking change

- [ x ] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)