### PR TITLE
Isdevops 215 add var for ingester replicas

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -43,7 +43,8 @@ locals {
           persistence = {
             enabled = true
           }
-          replicas = 3
+          replicas       = "${var.ingester_config.replicas}"
+          maxUnavailable = "${var.ingester_config.maxUnavailable}"
         }
         loki = {
           structuredConfig = {

--- a/locals.tf
+++ b/locals.tf
@@ -43,7 +43,7 @@ locals {
           persistence = {
             enabled = true
           }
-          replicas = 1
+          replicas = 3
         }
         loki = {
           structuredConfig = {

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,16 @@ variable "enable_filebeat" {
   type    = bool
   default = false
 }
+
+variable "ingester_config" {
+  description = "Configuration of ingester to have more replicas"
+  type = object({
+    replicas       = number
+    maxUnavailable = number
+  })
+  default = {
+    replicas       = 1
+    maxUnavailable = null
+  }
+}
+


### PR DESCRIPTION
## Description of the changes

The current distributed Loki deploys a single replica of the ingester component. This can lead to log write interruptions and potential data loss during rollouts and restarts. So I added a variable that allows to create more replicas for ingester.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)