### PR TITLE
feat: add variable that activate compactor retention

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.2"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -155,28 +155,6 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_ingester_config]] <<input_ingester_config,ingester_config>>
-
-Description: Configuration of ingester to have more replicas
-
-Type:
-[source,hcl]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-Default:
-[source,json]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 === Outputs
 
 The following outputs are exported:
@@ -207,11 +185,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -254,7 +232,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.2"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -327,30 +305,6 @@ object({
 |n/a
 |`bool`
 |`false`
-|no
-
-|[[input_ingester_config]] <<input_ingester_config,ingester_config>>
-|Configuration of ingester to have more replicas
-|
-
-[source]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-|
-
-[source]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 |no
 
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -155,6 +155,36 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+
+Description: This variable allows to enable the retention of compactor for Loki
+
+Type:
+[source,hcl]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -185,11 +215,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -305,6 +335,38 @@ object({
 |n/a
 |`bool`
 |`false`
+|no
+
+|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+|This variable allows to enable the retention of compactor for Loki
+|
+
+[source]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+|
+
+[source]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -93,7 +93,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.2"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -174,28 +174,6 @@ Description: n/a
 Type: `bool`
 
 Default: `false`
-
-==== [[input_ingester_config]] <<input_ingester_config,ingester_config>>
-
-Description: Configuration of ingester to have more replicas
-
-Type:
-[source,hcl]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-Default:
-[source,json]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
 
 === Outputs
 
@@ -294,7 +272,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.2"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -367,30 +345,6 @@ object({
 |n/a
 |`bool`
 |`false`
-|no
-
-|[[input_ingester_config]] <<input_ingester_config,ingester_config>>
-|Configuration of ingester to have more replicas
-|
-
-[source]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-|
-
-[source]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -175,6 +175,36 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+
+Description: This variable allows to enable the retention of compactor for Loki
+
+Type:
+[source,hcl]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -345,6 +375,38 @@ object({
 |n/a
 |`bool`
 |`false`
+|no
+
+|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+|This variable allows to enable the retention of compactor for Loki
+|
+
+[source]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+|
+
+[source]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -157,6 +157,36 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+
+Description: This variable allows to enable the retention of compactor for Loki
+
+Type:
+[source,hcl]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -305,6 +335,38 @@ object({
 |n/a
 |`bool`
 |`false`
+|no
+
+|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+|This variable allows to enable the retention of compactor for Loki
+|
+
+[source]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+|
+
+[source]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.2"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -157,28 +157,6 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_ingester_config]] <<input_ingester_config,ingester_config>>
-
-Description: Configuration of ingester to have more replicas
-
-Type:
-[source,hcl]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-Default:
-[source,json]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 === Outputs
 
 The following outputs are exported:
@@ -254,7 +232,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.2"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -327,30 +305,6 @@ object({
 |n/a
 |`bool`
 |`false`
-|no
-
-|[[input_ingester_config]] <<input_ingester_config,ingester_config>>
-|Configuration of ingester to have more replicas
-|
-
-[source]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-|
-
-[source]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -76,7 +76,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.2"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -158,28 +158,6 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_ingester_config]] <<input_ingester_config,ingester_config>>
-
-Description: Configuration of ingester to have more replicas
-
-Type:
-[source,hcl]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-Default:
-[source,json]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 === Outputs
 
 The following outputs are exported:
@@ -256,7 +234,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.2"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -329,30 +307,6 @@ object({
 |n/a
 |`bool`
 |`false`
-|no
-
-|[[input_ingester_config]] <<input_ingester_config,ingester_config>>
-|Configuration of ingester to have more replicas
-|
-
-[source]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-|
-
-[source]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -158,6 +158,36 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+
+Description: This variable allows to enable the retention of compactor for Loki
+
+Type:
+[source,hcl]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -307,6 +337,38 @@ object({
 |n/a
 |`bool`
 |`false`
+|no
+
+|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+|This variable allows to enable the retention of compactor for Loki
+|
+
+[source]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+|
+
+[source]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 |no
 
 |===

--- a/locals.tf
+++ b/locals.tf
@@ -45,7 +45,7 @@ locals {
           }
           replicas       = "3"
           maxUnavailable = "1"
-          affinity = {}
+          affinity       = {}
         }
         loki = {
           structuredConfig = {

--- a/locals.tf
+++ b/locals.tf
@@ -43,9 +43,9 @@ locals {
           persistence = {
             enabled = true
           }
-          replicas       = "3"
-          maxUnavailable = "1"
-          affinity       = {}
+          replicas       = 3
+          maxUnavailable = 1
+          affinity       = ""
         }
         loki = {
           structuredConfig = {

--- a/locals.tf
+++ b/locals.tf
@@ -43,8 +43,9 @@ locals {
           persistence = {
             enabled = true
           }
-          replicas       = "${var.ingester_config.replicas}"
-          maxUnavailable = "${var.ingester_config.maxUnavailable}"
+          replicas       = "3"
+          maxUnavailable = "1"
+          affinity = {}
         }
         loki = {
           structuredConfig = {
@@ -70,6 +71,11 @@ locals {
               retention_enabled      = false
             }
             ingester = {
+              lifecycler = {
+                ring = {
+                  replication_factor = 3
+                }
+              }
               wal = {
                 replay_memory_ceiling = "500MB"
                 flush_on_shutdown     = true

--- a/locals.tf
+++ b/locals.tf
@@ -38,7 +38,6 @@ locals {
             enabled = true
           }
         }
-        # TODO ingester HA
         ingester = {
           persistence = {
             enabled = true
@@ -67,8 +66,7 @@ locals {
               }
             }
             compactor = {
-              retention_delete_delay = "1h"
-              retention_enabled      = false
+              retention_enabled = "${var.compactor_retention.compactor.retention_enabled}"
             }
             ingester = {
               lifecycler = {
@@ -88,7 +86,7 @@ locals {
               max_query_length            = "9000h"
               max_query_parallelism       = 6
               per_stream_rate_limit       = "10MB"
-              retention_period            = "9000h"
+              retention_period            = "${var.compactor_retention.limits_config.retention_period}"
             }
             querier = {
               max_concurrent = 2

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,24 @@ variable "enable_filebeat" {
   type    = bool
   default = false
 }
+
+variable "compactor_retention" {
+  description = "This variable allows to enable the retention of compactor for Loki"
+  type = object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+
+  default = {
+    compactor = {
+      retention_enabled = "true"
+    }
+    limits_config = {
+      retention_period = "720h"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -83,16 +83,3 @@ variable "enable_filebeat" {
   type    = bool
   default = false
 }
-
-variable "ingester_config" {
-  description = "Configuration of ingester to have more replicas"
-  type = object({
-    replicas       = number
-    maxUnavailable = number
-  })
-  default = {
-    replicas       = 1
-    maxUnavailable = null
-  }
-}
-


### PR DESCRIPTION
## Description of the changes

Creation of a Module variable that enables the retention of the Loki compactor because in the current configuration it is disabled.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)