### PR TITLE
feat: configure ingester replication factor

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.2"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -155,28 +155,6 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_ingester_config]] <<input_ingester_config,ingester_config>>
-
-Description: Configuration of ingester to have more replicas
-
-Type:
-[source,hcl]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-Default:
-[source,json]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 === Outputs
 
 The following outputs are exported:
@@ -207,11 +185,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -254,7 +232,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.2"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -327,30 +305,6 @@ object({
 |n/a
 |`bool`
 |`false`
-|no
-
-|[[input_ingester_config]] <<input_ingester_config,ingester_config>>
-|Configuration of ingester to have more replicas
-|
-
-[source]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-|
-
-[source]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 |no
 
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -26,6 +24,8 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -185,11 +185,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -93,7 +93,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.2"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -174,28 +174,6 @@ Description: n/a
 Type: `bool`
 
 Default: `false`
-
-==== [[input_ingester_config]] <<input_ingester_config,ingester_config>>
-
-Description: Configuration of ingester to have more replicas
-
-Type:
-[source,hcl]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-Default:
-[source,json]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
 
 === Outputs
 
@@ -294,7 +272,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.2"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -367,30 +345,6 @@ object({
 |n/a
 |`bool`
 |`false`
-|no
-
-|[[input_ingester_config]] <<input_ingester_config,ingester_config>>
-|Configuration of ingester to have more replicas
-|
-
-[source]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-|
-
-[source]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.2"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -157,28 +157,6 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_ingester_config]] <<input_ingester_config,ingester_config>>
-
-Description: Configuration of ingester to have more replicas
-
-Type:
-[source,hcl]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-Default:
-[source,json]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 === Outputs
 
 The following outputs are exported:
@@ -254,7 +232,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.2"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -327,30 +305,6 @@ object({
 |n/a
 |`bool`
 |`false`
-|no
-
-|[[input_ingester_config]] <<input_ingester_config,ingester_config>>
-|Configuration of ingester to have more replicas
-|
-
-[source]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-|
-
-[source]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -76,7 +76,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.2"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -158,28 +158,6 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_ingester_config]] <<input_ingester_config,ingester_config>>
-
-Description: Configuration of ingester to have more replicas
-
-Type:
-[source,hcl]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-Default:
-[source,json]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 === Outputs
 
 The following outputs are exported:
@@ -256,7 +234,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.2"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -329,30 +307,6 @@ object({
 |n/a
 |`bool`
 |`false`
-|no
-
-|[[input_ingester_config]] <<input_ingester_config,ingester_config>>
-|Configuration of ingester to have more replicas
-|
-
-[source]
-----
-object({
-    replicas       = number
-    maxUnavailable = number
-  })
-----
-
-|
-
-[source]
-----
-{
-  "maxUnavailable": null,
-  "replicas": 1
-}
-----
-
 |no
 
 |===

--- a/locals.tf
+++ b/locals.tf
@@ -45,7 +45,7 @@ locals {
           }
           replicas       = "3"
           maxUnavailable = "1"
-          affinity = {}
+          affinity       = {}
         }
         loki = {
           structuredConfig = {

--- a/locals.tf
+++ b/locals.tf
@@ -43,9 +43,9 @@ locals {
           persistence = {
             enabled = true
           }
-          replicas       = "3"
-          maxUnavailable = "1"
-          affinity       = {}
+          replicas       = 3
+          maxUnavailable = 1
+          affinity       = ""
         }
         loki = {
           structuredConfig = {

--- a/locals.tf
+++ b/locals.tf
@@ -43,8 +43,9 @@ locals {
           persistence = {
             enabled = true
           }
-          replicas       = "${var.ingester_config.replicas}"
-          maxUnavailable = "${var.ingester_config.maxUnavailable}"
+          replicas       = "3"
+          maxUnavailable = "1"
+          affinity = {}
         }
         loki = {
           structuredConfig = {
@@ -70,6 +71,11 @@ locals {
               retention_enabled      = false
             }
             ingester = {
+              lifecycler = {
+                ring = {
+                  replication_factor = 3
+                }
+              }
               wal = {
                 replay_memory_ceiling = "500MB"
                 flush_on_shutdown     = true

--- a/variables.tf
+++ b/variables.tf
@@ -83,16 +83,3 @@ variable "enable_filebeat" {
   type    = bool
   default = false
 }
-
-variable "ingester_config" {
-  description = "Configuration of ingester to have more replicas"
-  type = object({
-    replicas       = number
-    maxUnavailable = number
-  })
-  default = {
-    replicas       = 1
-    maxUnavailable = null
-  }
-}
-


### PR DESCRIPTION
## Description of the changes

As the current distributed Loki deploys a single replica of the ingester component, this can lead to log write interruptions and potential data loss during rollouts and restarts. So I configured the ingester to be deployed with replication factor of 3 and removed PodAffinity rules for the ingester to have replicas to any number of nodes (a nice feature to add later will be soft node affinity rules to make sure the ingester replicas are evenly deployed on multiples nodes).

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)