### PR TITLE
feat: add var that enables compactor retention

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -24,8 +26,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -141,11 +141,11 @@ Default: `false`
 
 ==== [[input_retention]] <<input_retention,retention>>
 
-Description: Variable to define retention period. To deactivate retention, pass 0s to the variable.
+Description: Logs retention period.To deactivate retention, pass 0s.
 
 Type: `string`
 
-Default: `"720h"`
+Default: `"30d"`
 
 === Outputs
 
@@ -288,9 +288,9 @@ object({
 |no
 
 |[[input_retention]] <<input_retention,retention>>
-|Variable to define retention period. To deactivate retention, pass 0s to the variable.
+|Logs retention period.To deactivate retention, pass 0s.
 |`string`
-|`"720h"`
+|`"30d"`
 |no
 
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -139,6 +139,36 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+
+Description: This variable allows to enable the retention of compactor for Loki
+
+Type:
+[source,hcl]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -172,8 +202,8 @@ Description: n/a
 |[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |===
 
 = Resources
@@ -277,6 +307,38 @@ object({
 |n/a
 |`bool`
 |`false`
+|no
+
+|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+|This variable allows to enable the retention of compactor for Loki
+|
+
+[source]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+|
+
+[source]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 |no
 
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -26,6 +24,8 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -139,35 +139,13 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+==== [[input_retention]] <<input_retention,retention>>
 
-Description: This variable allows to enable the retention of compactor for Loki
+Description: Variable to define retention period. To deactivate retention, pass 0s to the variable.
 
-Type:
-[source,hcl]
-----
-object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
-----
+Type: `string`
 
-Default:
-[source,json]
-----
-{
-  "compactor": {
-    "retention_enabled": "true"
-  },
-  "limits_config": {
-    "retention_period": "720h"
-  }
-}
-----
+Default: `"720h"`
 
 === Outputs
 
@@ -309,36 +287,10 @@ object({
 |`false`
 |no
 
-|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
-|This variable allows to enable the retention of compactor for Loki
-|
-
-[source]
-----
-object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
-----
-
-|
-
-[source]
-----
-{
-  "compactor": {
-    "retention_enabled": "true"
-  },
-  "limits_config": {
-    "retention_period": "720h"
-  }
-}
-----
-
+|[[input_retention]] <<input_retention,retention>>
+|Variable to define retention period. To deactivate retention, pass 0s to the variable.
+|`string`
+|`"720h"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -159,6 +159,36 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+
+Description: This variable allows to enable the retention of compactor for Loki
+
+Type:
+[source,hcl]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -317,6 +347,38 @@ object({
 |n/a
 |`bool`
 |`false`
+|no
+
+|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+|This variable allows to enable the retention of compactor for Loki
+|
+
+[source]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+|
+
+[source]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -161,11 +161,11 @@ Default: `false`
 
 ==== [[input_retention]] <<input_retention,retention>>
 
-Description: Variable to define retention period. To deactivate retention, pass 0s to the variable.
+Description: Logs retention period.To deactivate retention, pass 0s.
 
 Type: `string`
 
-Default: `"720h"`
+Default: `"30d"`
 
 === Outputs
 
@@ -328,9 +328,9 @@ object({
 |no
 
 |[[input_retention]] <<input_retention,retention>>
-|Variable to define retention period. To deactivate retention, pass 0s to the variable.
+|Logs retention period.To deactivate retention, pass 0s.
 |`string`
-|`"720h"`
+|`"30d"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -159,35 +159,13 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+==== [[input_retention]] <<input_retention,retention>>
 
-Description: This variable allows to enable the retention of compactor for Loki
+Description: Variable to define retention period. To deactivate retention, pass 0s to the variable.
 
-Type:
-[source,hcl]
-----
-object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
-----
+Type: `string`
 
-Default:
-[source,json]
-----
-{
-  "compactor": {
-    "retention_enabled": "true"
-  },
-  "limits_config": {
-    "retention_period": "720h"
-  }
-}
-----
+Default: `"720h"`
 
 === Outputs
 
@@ -349,36 +327,10 @@ object({
 |`false`
 |no
 
-|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
-|This variable allows to enable the retention of compactor for Loki
-|
-
-[source]
-----
-object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
-----
-
-|
-
-[source]
-----
-{
-  "compactor": {
-    "retention_enabled": "true"
-  },
-  "limits_config": {
-    "retention_period": "720h"
-  }
-}
-----
-
+|[[input_retention]] <<input_retention,retention>>
+|Variable to define retention period. To deactivate retention, pass 0s to the variable.
+|`string`
+|`"720h"`
 |no
 
 |===

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -47,6 +47,7 @@ module "loki-stack" {
   app_autosync     = var.app_autosync
   dependency_ids   = var.dependency_ids
 
+  retention        = var.retention
   distributed_mode = var.distributed_mode
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -143,11 +143,11 @@ Default: `false`
 
 ==== [[input_retention]] <<input_retention,retention>>
 
-Description: Variable to define retention period. To deactivate retention, pass 0s to the variable.
+Description: Logs retention period.To deactivate retention, pass 0s.
 
 Type: `string`
 
-Default: `"720h"`
+Default: `"30d"`
 
 === Outputs
 
@@ -288,9 +288,9 @@ object({
 |no
 
 |[[input_retention]] <<input_retention,retention>>
-|Variable to define retention period. To deactivate retention, pass 0s to the variable.
+|Logs retention period.To deactivate retention, pass 0s.
 |`string`
-|`"720h"`
+|`"30d"`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -141,35 +141,13 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+==== [[input_retention]] <<input_retention,retention>>
 
-Description: This variable allows to enable the retention of compactor for Loki
+Description: Variable to define retention period. To deactivate retention, pass 0s to the variable.
 
-Type:
-[source,hcl]
-----
-object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
-----
+Type: `string`
 
-Default:
-[source,json]
-----
-{
-  "compactor": {
-    "retention_enabled": "true"
-  },
-  "limits_config": {
-    "retention_period": "720h"
-  }
-}
-----
+Default: `"720h"`
 
 === Outputs
 
@@ -309,36 +287,10 @@ object({
 |`false`
 |no
 
-|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
-|This variable allows to enable the retention of compactor for Loki
-|
-
-[source]
-----
-object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
-----
-
-|
-
-[source]
-----
-{
-  "compactor": {
-    "retention_enabled": "true"
-  },
-  "limits_config": {
-    "retention_period": "720h"
-  }
-}
-----
-
+|[[input_retention]] <<input_retention,retention>>
+|Variable to define retention period. To deactivate retention, pass 0s to the variable.
+|`string`
+|`"720h"`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -141,6 +141,36 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+
+Description: This variable allows to enable the retention of compactor for Loki
+
+Type:
+[source,hcl]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -277,6 +307,38 @@ object({
 |n/a
 |`bool`
 |`false`
+|no
+
+|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+|This variable allows to enable the retention of compactor for Loki
+|
+
+[source]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+|
+
+[source]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 |no
 
 |===

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -7,6 +7,7 @@ module "loki-stack" {
   app_autosync     = var.app_autosync
   dependency_ids   = var.dependency_ids
 
+  retention        = var.retention
   distributed_mode = var.distributed_mode
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -144,11 +144,11 @@ Default: `false`
 
 ==== [[input_retention]] <<input_retention,retention>>
 
-Description: Variable to define retention period. To deactivate retention, pass 0s to the variable.
+Description: Logs retention period.To deactivate retention, pass 0s.
 
 Type: `string`
 
-Default: `"720h"`
+Default: `"30d"`
 
 === Outputs
 
@@ -290,9 +290,9 @@ object({
 |no
 
 |[[input_retention]] <<input_retention,retention>>
-|Variable to define retention period. To deactivate retention, pass 0s to the variable.
+|Logs retention period.To deactivate retention, pass 0s.
 |`string`
-|`"720h"`
+|`"30d"`
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -142,35 +142,13 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+==== [[input_retention]] <<input_retention,retention>>
 
-Description: This variable allows to enable the retention of compactor for Loki
+Description: Variable to define retention period. To deactivate retention, pass 0s to the variable.
 
-Type:
-[source,hcl]
-----
-object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
-----
+Type: `string`
 
-Default:
-[source,json]
-----
-{
-  "compactor": {
-    "retention_enabled": "true"
-  },
-  "limits_config": {
-    "retention_period": "720h"
-  }
-}
-----
+Default: `"720h"`
 
 === Outputs
 
@@ -311,36 +289,10 @@ object({
 |`false`
 |no
 
-|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
-|This variable allows to enable the retention of compactor for Loki
-|
-
-[source]
-----
-object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
-----
-
-|
-
-[source]
-----
-{
-  "compactor": {
-    "retention_enabled": "true"
-  },
-  "limits_config": {
-    "retention_period": "720h"
-  }
-}
-----
-
+|[[input_retention]] <<input_retention,retention>>
+|Variable to define retention period. To deactivate retention, pass 0s to the variable.
+|`string`
+|`"720h"`
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -142,6 +142,36 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+
+Description: This variable allows to enable the retention of compactor for Loki
+
+Type:
+[source,hcl]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -279,6 +309,38 @@ object({
 |n/a
 |`bool`
 |`false`
+|no
+
+|[[input_compactor_retention]] <<input_compactor_retention,compactor_retention>>
+|This variable allows to enable the retention of compactor for Loki
+|
+
+[source]
+----
+object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+----
+
+|
+
+[source]
+----
+{
+  "compactor": {
+    "retention_enabled": "true"
+  },
+  "limits_config": {
+    "retention_period": "720h"
+  }
+}
+----
+
 |no
 
 |===

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -7,6 +7,7 @@ module "loki-stack" {
   app_autosync     = var.app_autosync
   dependency_ids   = var.dependency_ids
 
+  retention        = var.retention
   distributed_mode = var.distributed_mode
   ingress          = var.ingress
   enable_filebeat  = var.enable_filebeat

--- a/locals.tf
+++ b/locals.tf
@@ -67,8 +67,7 @@ locals {
               }
             }
             compactor = {
-              retention_delete_delay = "1h"
-              retention_enabled      = false
+              retention_enabled = "${var.compactor_retention.compactor.retention_enabled}"
             }
             ingester = {
               lifecycler = {
@@ -88,7 +87,7 @@ locals {
               max_query_length            = "9000h"
               max_query_parallelism       = 6
               per_stream_rate_limit       = "10MB"
-              retention_period            = "9000h"
+              retention_period            = "${var.compactor_retention.limits_config.retention_period}"
             }
             querier = {
               max_concurrent = 2

--- a/locals.tf
+++ b/locals.tf
@@ -67,7 +67,7 @@ locals {
               }
             }
             compactor = {
-              retention_enabled = var.retention != "0s"
+              retention_enabled = true
             }
             ingester = {
               lifecycler = {

--- a/locals.tf
+++ b/locals.tf
@@ -67,7 +67,7 @@ locals {
               }
             }
             compactor = {
-              retention_enabled = "${var.compactor_retention.compactor.retention_enabled}"
+              retention_enabled = var.retention != "0s"
             }
             ingester = {
               lifecycler = {
@@ -87,7 +87,7 @@ locals {
               max_query_length            = "9000h"
               max_query_parallelism       = 6
               per_stream_rate_limit       = "10MB"
-              retention_period            = "${var.compactor_retention.limits_config.retention_period}"
+              retention_period            = var.retention
             }
             querier = {
               max_concurrent = 2

--- a/locals.tf
+++ b/locals.tf
@@ -84,7 +84,7 @@ locals {
               ingestion_rate_mb           = 10
               max_chunks_per_query        = 0
               max_entries_limit_per_query = 0
-              max_query_length            = "9000h"
+              max_query_length            = var.retention
               max_query_parallelism       = 6
               per_stream_rate_limit       = "10MB"
               retention_period            = var.retention

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,24 @@ variable "enable_filebeat" {
   type        = bool
   default     = false
 }
+
+variable "compactor_retention" {
+  description = "This variable allows to enable the retention of compactor for Loki"
+  type = object({
+    compactor = object({
+      retention_enabled = bool
+    })
+    limits_config = object({
+      retention_period = string
+    })
+  })
+
+  default = {
+    compactor = {
+      retention_enabled = "true"
+    }
+    limits_config = {
+      retention_period = "720h"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -73,9 +73,9 @@ variable "enable_filebeat" {
 }
 
 variable "retention" {
-  description = "Variable to define retention period. To deactivate retention, pass 0s to the variable."
+  description = "Logs retention period.To deactivate retention, pass 0s."
   type        = string
-  default     = "720h"
+  default     = "30d"
 
   validation {
     condition     = var.retention != null

--- a/variables.tf
+++ b/variables.tf
@@ -72,23 +72,13 @@ variable "enable_filebeat" {
   default     = false
 }
 
-variable "compactor_retention" {
-  description = "This variable allows to enable the retention of compactor for Loki"
-  type = object({
-    compactor = object({
-      retention_enabled = bool
-    })
-    limits_config = object({
-      retention_period = string
-    })
-  })
+variable "retention" {
+  description = "Variable to define retention period. To deactivate retention, pass 0s to the variable."
+  type        = string
+  default     = "720h"
 
-  default = {
-    compactor = {
-      retention_enabled = "true"
-    }
-    limits_config = {
-      retention_period = "720h"
-    }
+  validation {
+    condition     = var.retention != null
+    error_message = "Variable must not be null."
   }
 }


### PR DESCRIPTION
## Description of the changes

Creation of a module variable that enables the retention of the Loki compactor because in the current configuration it is disabled.

:warning: **ATTENTION** :warning:
Platforms that use this module and do not apply retention - or have a longer retention window - need to update the retention input to avoid data loss.

## Breaking change

- [x] No


## Tests executed on which distribution(s)

- [x] KinD
- [x] EKS (AWS)