### PR TITLE
feat/fix: add SKS variant and standardize bucket configuration on other variants

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -8,4 +8,4 @@ jobs:
   terraform-docs:
     uses: camptocamp/devops-stack/.github/workflows/modules-terraform-docs.yaml@main
     with:
-      variants: "aks,eks,kind"
+      variants: "aks,eks,kind,sks"

--- a/README.adoc
+++ b/README.adoc
@@ -57,7 +57,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.3.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -157,7 +157,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 
 ==== [[output_loki_credentials]] <<output_loki_credentials,loki_credentials>>
 
-Description: n/a
+Description: Credentials to access the Loki ingress, if activated.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -177,11 +177,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -212,7 +212,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.3.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -301,6 +301,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
-|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |n/a
+|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |Credentials to access the Loki ingress, if activated.
 |===
 // END_TF_TABLES

--- a/README.adoc
+++ b/README.adoc
@@ -23,9 +23,9 @@ The following providers are used by this module:
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
-
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -177,11 +177,11 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.3.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -173,11 +173,11 @@ The following outputs are exported:
 
 ==== [[output_id]] <<output_id,id>>
 
-Description: ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place.
+Description: ID to pass other modules in order to refer to this module as a dependency.
 
 ==== [[output_loki_credentials]] <<output_loki_credentials,loki_credentials>>
 
-Description: n/a
+Description: Credentials to access the Loki ingress, if activated.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -252,7 +252,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.3.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -340,7 +340,7 @@ object({
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Description
-|[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place.
-|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |n/a
+|[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |Credentials to access the Loki ingress, if activated.
 |===
 // END_TF_TABLES

--- a/aks/outputs.tf
+++ b/aks/outputs.tf
@@ -1,9 +1,10 @@
 output "id" {
-  description = "ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place."
+  description = "ID to pass other modules in order to refer to this module as a dependency."
   value       = module.loki-stack.id
 }
 
 output "loki_credentials" {
-  value     = module.loki-stack.loki_credentials
-  sensitive = true
+  description = "Credentials to access the Loki ingress, if activated."
+  value       = module.loki-stack.loki_credentials
+  sensitive   = true
 }

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -59,7 +59,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.3.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -155,11 +155,11 @@ The following outputs are exported:
 
 ==== [[output_id]] <<output_id,id>>
 
-Description: ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place.
+Description: ID to pass other modules in order to refer to this module as a dependency.
 
 ==== [[output_loki_credentials]] <<output_loki_credentials,loki_credentials>>
 
-Description: n/a
+Description: Credentials to access the Loki ingress, if activated.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -212,7 +212,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.3.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -300,7 +300,7 @@ object({
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Description
-|[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place.
-|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |n/a
+|[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |Credentials to access the Loki ingress, if activated.
 |===
 // END_TF_TABLES

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -1,9 +1,10 @@
 output "id" {
-  description = "ID to pass other modules in order to refer to this module as a dependency. It takes the ID that comes from the main module and passes it along to the code that called this variant in the first place."
+  description = "ID to pass other modules in order to refer to this module as a dependency."
   value       = module.loki-stack.id
 }
 
 output "loki_credentials" {
-  value     = module.loki-stack.loki_credentials
-  sensitive = true
+  description = "Credentials to access the Loki ingress, if activated."
+  value       = module.loki-stack.loki_credentials
+  sensitive   = true
 }

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -35,10 +35,11 @@ Type:
 [source,hcl]
 ----
 object({
-    bucket_name       = string
-    endpoint          = string
-    access_key        = string
-    secret_access_key = string
+    bucket_name = string
+    endpoint    = string
+    access_key  = string
+    secret_key  = string
+    insecure    = optional(bool, true)
   })
 ----
 
@@ -60,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.3.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -156,11 +157,11 @@ The following outputs are exported:
 
 ==== [[output_id]] <<output_id,id>>
 
-Description: n/a
+Description: ID to pass other modules in order to refer to this module as a dependency.
 
 ==== [[output_loki_credentials]] <<output_loki_credentials,loki_credentials>>
 
-Description: n/a
+Description: Credentials to access the Loki ingress, if activated.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -195,10 +196,11 @@ Description: n/a
 [source]
 ----
 object({
-    bucket_name       = string
-    endpoint          = string
-    access_key        = string
-    secret_access_key = string
+    bucket_name = string
+    endpoint    = string
+    access_key  = string
+    secret_key  = string
+    insecure    = optional(bool, true)
   })
 ----
 
@@ -214,7 +216,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.3.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -302,7 +304,7 @@ object({
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Description
-|[[output_id]] <<output_id,id>> |n/a
-|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |n/a
+|[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |Credentials to access the Loki ingress, if activated.
 |===
 // END_TF_TABLES

--- a/kind/extra-variables.tf
+++ b/kind/extra-variables.tf
@@ -5,6 +5,6 @@ variable "logs_storage" {
     endpoint    = string
     access_key  = string
     secret_key  = string
-    insecure    = optional(bool, false)
+    insecure    = optional(bool, true)
   })
 }

--- a/kind/extra-variables.tf
+++ b/kind/extra-variables.tf
@@ -1,9 +1,10 @@
 variable "logs_storage" {
   description = "MinIO S3 bucket configuration values for the bucket where the logs will be stored."
   type = object({
-    bucket_name       = string
-    endpoint          = string
-    access_key        = string
-    secret_access_key = string
+    bucket_name = string
+    endpoint    = string
+    access_key  = string
+    secret_key  = string
+    insecure    = optional(bool, false)
   })
 }

--- a/kind/locals.tf
+++ b/kind/locals.tf
@@ -52,9 +52,9 @@ locals {
       bucketnames       = "${var.logs_storage.bucket_name}"
       endpoint          = "${var.logs_storage.endpoint}"
       access_key_id     = "${var.logs_storage.access_key}"
-      secret_access_key = "${var.logs_storage.secret_access_key}"
+      secret_access_key = "${var.logs_storage.secret_key}"
       s3forcepathstyle  = true
-      insecure          = true
+      insecure          = var.logs_storage.insecure
     }
     boltdb_shipper = {
       shared_store = "aws"

--- a/kind/outputs.tf
+++ b/kind/outputs.tf
@@ -1,8 +1,10 @@
 output "id" {
-  value = module.loki-stack.id
+  description = "ID to pass other modules in order to refer to this module as a dependency."
+  value       = module.loki-stack.id
 }
 
 output "loki_credentials" {
-  value     = module.loki-stack.loki_credentials
-  sensitive = true
+  description = "Credentials to access the Loki ingress, if activated."
+  value       = module.loki-stack.loki_credentials
+  sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,7 @@ output "id" {
 }
 
 output "loki_credentials" {
+  description = "Credentials to access the Loki ingress, if activated."
   value = var.ingress != null ? {
     username = "loki"
     password = random_password.loki_password.0.result

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -47,6 +47,174 @@ Obviously, the module depends on an already running Argo CD in the cluster in or
 This module requires a Persistent Volume so it needs to be deployed after the module Longhorn.
 
 // BEGIN_TF_DOCS
+=== Requirements
+
+The following requirements are needed by this module:
+
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+
+- [[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> (>= 1)
+
+- [[requirement_null]] <<requirement_null,null>> (>= 3)
+
+- [[requirement_random]] <<requirement_random,random>> (>= 3)
+
+- [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
+
+=== Modules
+
+The following Modules are called:
+
+==== [[module_loki-stack]] <<module_loki-stack,loki-stack>>
+
+Source: ../
+
+Version:
+
+=== Required Inputs
+
+The following input variables are required:
+
+==== [[input_cluster_id]] <<input_cluster_id,cluster_id>>
+
+Description: ID of the SKS cluster.
+
+Type: `string`
+
+==== [[input_logs_storage]] <<input_logs_storage,logs_storage>>
+
+Description: Exoscale SOS bucket configuration values for the bucket where the logs will be stored.
+
+Type:
+[source,hcl]
+----
+object({
+    bucket_name = string
+    region      = string
+    access_key  = string
+    secret_key  = string
+  })
+----
+
+=== Optional Inputs
+
+The following input variables are optional (have default values):
+
+==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
+
+Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
+
+Type: `string`
+
+Default: `"argocd"`
+
+==== [[input_target_revision]] <<input_target_revision,target_revision>>
+
+Description: Override of target revision of the application chart.
+
+Type: `string`
+
+Default: `"v2.3.0"`
+
+==== [[input_namespace]] <<input_namespace,namespace>>
+
+Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
+
+Type: `string`
+
+Default: `"loki-stack"`
+
+==== [[input_helm_values]] <<input_helm_values,helm_values>>
+
+Description: Helm chart value overrides. They should be passed as a list of HCL structures.
+
+Type: `any`
+
+Default: `[]`
+
+==== [[input_app_autosync]] <<input_app_autosync,app_autosync>>
+
+Description: Automated sync options for the Argo CD Application resource.
+
+Type:
+[source,hcl]
+----
+object({
+    allow_empty = optional(bool)
+    prune       = optional(bool)
+    self_heal   = optional(bool)
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "allow_empty": false,
+  "prune": true,
+  "self_heal": true
+}
+----
+
+==== [[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
+
+Description: IDs of the other modules on which this module depends on.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_distributed_mode]] <<input_distributed_mode,distributed_mode>>
+
+Description: Boolean to activate Loki in distributed mode.
+
+Type: `bool`
+
+Default: `false`
+
+==== [[input_ingress]] <<input_ingress,ingress>>
+
+Description: Loki frontend ingress configuration.
+
+Type:
+[source,hcl]
+----
+object({
+    hosts          = list(string)
+    cluster_issuer = string
+    allowed_ips    = optional(list(string), [])
+  })
+----
+
+Default: `null`
+
+==== [[input_enable_filebeat]] <<input_enable_filebeat,enable_filebeat>>
+
+Description: n/a
+
+Type: `bool`
+
+Default: `false`
+
+==== [[input_retention]] <<input_retention,retention>>
+
+Description: Logs retention period.To deactivate retention, pass 0s.
+
+Type: `string`
+
+Default: `"30d"`
+
+=== Outputs
+
+The following outputs are exported:
+
+==== [[output_id]] <<output_id,id>>
+
+Description: ID to pass other modules in order to refer to this module as a dependency.
+
+==== [[output_loki_credentials]] <<output_loki_credentials,loki_credentials>>
+
+Description: Credentials to access the Loki ingress, if activated.
 // END_TF_DOCS
 
 === Reference in table format 
@@ -55,5 +223,153 @@ This module requires a Persistent Volume so it needs to be deployed after the mo
 [%collapsible]
 ====
 // BEGIN_TF_TABLES
+= Requirements
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> |>= 1
+|[[requirement_null]] <<requirement_null,null>> |>= 3
+|[[requirement_random]] <<requirement_random,random>> |>= 3
+|[[requirement_utils]] <<requirement_utils,utils>> |>= 1
+|===
+
+= Modules
+
+[cols="a,a,a",options="header,autowidth"]
+|===
+|Name |Source |Version
+|[[module_loki-stack]] <<module_loki-stack,loki-stack>> |../ |
+|===
+
+= Inputs
+
+[cols="a,a,a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type |Default |Required
+|[[input_cluster_id]] <<input_cluster_id,cluster_id>>
+|ID of the SKS cluster.
+|`string`
+|n/a
+|yes
+
+|[[input_logs_storage]] <<input_logs_storage,logs_storage>>
+|Exoscale SOS bucket configuration values for the bucket where the logs will be stored.
+|
+
+[source]
+----
+object({
+    bucket_name = string
+    region      = string
+    access_key  = string
+    secret_key  = string
+  })
+----
+
+|n/a
+|yes
+
+|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
+|Namespace used by Argo CD where the Application and AppProject resources should be created.
+|`string`
+|`"argocd"`
+|no
+
+|[[input_target_revision]] <<input_target_revision,target_revision>>
+|Override of target revision of the application chart.
+|`string`
+|`"v2.3.0"`
+|no
+
+|[[input_namespace]] <<input_namespace,namespace>>
+|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
+|`string`
+|`"loki-stack"`
+|no
+
+|[[input_helm_values]] <<input_helm_values,helm_values>>
+|Helm chart value overrides. They should be passed as a list of HCL structures.
+|`any`
+|`[]`
+|no
+
+|[[input_app_autosync]] <<input_app_autosync,app_autosync>>
+|Automated sync options for the Argo CD Application resource.
+|
+
+[source]
+----
+object({
+    allow_empty = optional(bool)
+    prune       = optional(bool)
+    self_heal   = optional(bool)
+  })
+----
+
+|
+
+[source]
+----
+{
+  "allow_empty": false,
+  "prune": true,
+  "self_heal": true
+}
+----
+
+|no
+
+|[[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
+|IDs of the other modules on which this module depends on.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_distributed_mode]] <<input_distributed_mode,distributed_mode>>
+|Boolean to activate Loki in distributed mode.
+|`bool`
+|`false`
+|no
+
+|[[input_ingress]] <<input_ingress,ingress>>
+|Loki frontend ingress configuration.
+|
+
+[source]
+----
+object({
+    hosts          = list(string)
+    cluster_issuer = string
+    allowed_ips    = optional(list(string), [])
+  })
+----
+
+|`null`
+|no
+
+|[[input_enable_filebeat]] <<input_enable_filebeat,enable_filebeat>>
+|n/a
+|`bool`
+|`false`
+|no
+
+|[[input_retention]] <<input_retention,retention>>
+|Logs retention period.To deactivate retention, pass 0s.
+|`string`
+|`"30d"`
+|no
+
+|===
+
+= Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_loki_credentials]] <<output_loki_credentials,loki_credentials>> |Credentials to access the Loki ingress, if activated.
+|===
 // END_TF_TABLES
 ====

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -34,6 +34,54 @@ IMPORTANT: You are in charge of creating a S3 bucket for Loki to store the archi
 
 TIP: Check the xref:ROOT:ROOT:tutorials/deploy_sks.adoc[SKS deployment example] to see how to create the S3 bucket and to better understand the values passed on the example above.
 
+If there is a need to configure something besides the common settings that we have provided, you can customize the chart's `values.yaml` by adding an Helm configuration as an HCL structure:
+
+[source,terraform]
+----
+module "loki-stack" {
+  source = "git::https://github.com/camptocamp/devops-stack-module-loki-stack//sks?ref=<RELEASE>"
+
+  cluster_id       = module.sks.cluster_id
+  argocd_namespace = module.argocd_bootstrap.argocd_namespace
+
+  distributed_mode = true
+
+  logs_storage = {
+    bucket_name = resource.aws_s3_bucket.this["loki"].id
+    region      = resource.aws_s3_bucket.this["loki"].region
+    access_key  = resource.exoscale_iam_access_key.s3_iam_key["loki"].key
+    secret_key  = resource.exoscale_iam_access_key.s3_iam_key["loki"].secret
+  }
+
+  helm_values = [{ # Note the curly brackets here
+    loki-distributed = {
+      map = {
+        string = "string"
+        bool   = true
+      }
+      sequence = [
+        {
+          key1 = "value1"
+          key2 = "value2"
+        },
+        {
+          key1 = "value1"
+          key2 = "value2"
+        },
+      ]
+      sequence2 = [
+        "string1",
+        "string2"
+      ]
+    }
+  }]
+
+  dependency_ids = {
+    argocd   = module.argocd_bootstrap.id
+    longhorn = module.longhorn.id
+  }
+----
+
 == Technical Reference
 
 === Dependencies

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -1,0 +1,59 @@
+= SKS Variant
+
+This folder contains the variant to use when deploying in Exoscale using an SKS cluster.
+
+== Usage
+
+This module can be declared by adding the following block on your Terraform configuration:
+
+[source,terraform]
+----
+module "loki-stack" {
+  source = "git::https://github.com/camptocamp/devops-stack-module-loki-stack//sks?ref=<RELEASE>"
+
+  cluster_id       = module.sks.cluster_id
+  argocd_namespace = module.argocd_bootstrap.argocd_namespace
+
+  distributed_mode = true
+
+  logs_storage = {
+    bucket_name = resource.aws_s3_bucket.this["loki"].id
+    region      = resource.aws_s3_bucket.this["loki"].region
+    access_key  = resource.exoscale_iam_access_key.s3_iam_key["loki"].key
+    secret_key  = resource.exoscale_iam_access_key.s3_iam_key["loki"].secret
+  }
+
+  dependency_ids = {
+    argocd   = module.argocd_bootstrap.id
+    longhorn = module.longhorn.id
+  }
+}
+----
+
+IMPORTANT: You are in charge of creating a S3 bucket for Loki to store the archived logs. We've decided to keep the creation of this bucket outside of this module, mainly because the persistence of the data should not be related to the instantiation of the module itself.
+
+TIP: Check the xref:ROOT:ROOT:tutorials/deploy_sks.adoc[SKS deployment example] to see how to create the S3 bucket and to better understand the values passed on the example above.
+
+== Technical Reference
+
+=== Dependencies
+
+==== `module.argocd_bootstrap.id`
+
+Obviously, the module depends on an already running Argo CD in the cluster in order for the application to be created.
+
+==== `module.longhorn.id`
+
+This module requires a Persistent Volume so it needs to be deployed after the module Longhorn.
+
+// BEGIN_TF_DOCS
+// END_TF_DOCS
+
+=== Reference in table format 
+
+.Show tables
+[%collapsible]
+====
+// BEGIN_TF_TABLES
+// END_TF_TABLES
+====

--- a/sks/extra-variables.tf
+++ b/sks/extra-variables.tf
@@ -1,0 +1,14 @@
+variable "cluster_id" {
+  description = "ID of the SKS cluster."
+  type        = string
+}
+
+variable "logs_storage" {
+  description = "Exoscale SOS bucket configuration values for the bucket where the logs will be stored."
+  type = object({
+    bucket_name       = string
+    bucket_region     = string
+    access_key        = string
+    secret_access_key = string
+  })
+}

--- a/sks/extra-variables.tf
+++ b/sks/extra-variables.tf
@@ -6,9 +6,9 @@ variable "cluster_id" {
 variable "logs_storage" {
   description = "Exoscale SOS bucket configuration values for the bucket where the logs will be stored."
   type = object({
-    bucket_name       = string
-    bucket_region     = string
-    access_key        = string
-    secret_access_key = string
+    bucket_name = string
+    region      = string
+    access_key  = string
+    secret_key  = string
   })
 }

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -56,10 +56,10 @@ locals {
   storage_config = {
     aws = {
       bucketnames       = "${var.logs_storage.bucket_name}"
-      region            = "${var.logs_storage.bucket_region}"
-      endpoint          = "sos-${var.logs_storage.bucket_region}.exo.io"
+      region            = "${var.logs_storage.region}"
+      endpoint          = "sos-${var.logs_storage.region}.exo.io"
       access_key_id     = "${var.logs_storage.access_key}"
-      secret_access_key = "${var.logs_storage.secret_access_key}"
+      secret_access_key = "${var.logs_storage.secret_key}"
       s3forcepathstyle  = true
     }
     boltdb_shipper = {

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -72,6 +72,8 @@ locals {
     shared_store      = "s3"
   }
 
+  # These tolerations allow the pods to be scheduled on the router nodepool, otherwise we wouldn't be able to collect 
+  # the Traefik logs, since that nodepool is tainted and exclusively used for those pods.
   promtail_tolerations = [
     {
       key      = "nodepool"

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -1,0 +1,83 @@
+locals {
+  helm_values = [var.distributed_mode ? {
+    loki-distributed = {
+      global = {
+        clusterDomain = "${var.cluster_id}.cluster.local"
+      }
+      loki = {
+        schemaConfig  = local.schema_config
+        storageConfig = local.storage_config
+        structuredConfig = {
+          compactor = local.compactor
+        }
+      }
+    }
+    promtail = {
+      tolerations = local.promtail_tolerations
+    }
+    } : null, var.distributed_mode ? null : {
+    loki_stack = {
+      loki = {
+        config = {
+          ingester = {
+            lifecycler = {
+              ring = {
+                kvstore = {
+                  store = "memberlist"
+                }
+                replication_factor = 1
+              }
+              final_sleep = "0s"
+            }
+            chunk_idle_period   = "5m"
+            chunk_retain_period = "30s"
+          }
+          schema_config  = local.schema_config
+          storage_config = local.storage_config
+          compactor      = local.compactor
+        }
+      }
+    }
+  }]
+
+  schema_config = {
+    configs = [{
+      from         = "2020-10-24"
+      store        = "boltdb-shipper"
+      object_store = "s3"
+      schema       = "v11"
+      index = {
+        prefix = "index_"
+        period = "24h"
+      }
+    }]
+  }
+
+  storage_config = {
+    aws = {
+      bucketnames       = "${var.logs_storage.bucket_name}"
+      region            = "${var.logs_storage.bucket_region}"
+      endpoint          = "sos-${var.logs_storage.bucket_region}.exo.io"
+      access_key_id     = "${var.logs_storage.access_key}"
+      secret_access_key = "${var.logs_storage.secret_access_key}"
+      s3forcepathstyle  = true
+    }
+    boltdb_shipper = {
+      shared_store = "s3"
+    }
+  }
+
+  compactor = {
+    working_directory = "/data/compactor"
+    shared_store      = "s3"
+  }
+
+  promtail_tolerations = [
+    {
+      key      = "nodepool"
+      operator = "Equal"
+      value    = "router"
+      effect   = "NoSchedule"
+    },
+  ]
+}

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,0 +1,15 @@
+module "loki-stack" {
+  source = "../"
+
+  argocd_namespace = var.argocd_namespace
+  target_revision  = var.target_revision
+  namespace        = var.namespace
+  app_autosync     = var.app_autosync
+  dependency_ids   = var.dependency_ids
+
+  distributed_mode = var.distributed_mode
+  ingress          = var.ingress
+  enable_filebeat  = var.enable_filebeat
+
+  helm_values = concat(local.helm_values, var.helm_values)
+}

--- a/sks/outputs.tf
+++ b/sks/outputs.tf
@@ -1,0 +1,10 @@
+output "id" {
+  description = "ID to pass other modules in order to refer to this module as a dependency."
+  value       = module.loki-stack.id
+}
+
+output "loki_credentials" {
+  description = "Credentials to access the Loki ingress, if activated."
+  value       = module.loki-stack.loki_credentials
+  sensitive   = true
+}

--- a/sks/terraform.tf
+++ b/sks/terraform.tf
@@ -1,0 +1,1 @@
+../terraform.tf

--- a/sks/variables.tf
+++ b/sks/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf


### PR DESCRIPTION
## Description of the changes

This PR implements the SKS variant. It adds the necessary settings to use the S3 buckets on Exoscale and a nodeToleration to the Promtail, which is needed to deploy it on the router nodes that are tainted.

I also took the time to add a few descriptions to some outputs.

:warning: **Do a _Rebase and merge_.**

## Breaking change

- [x] Yes (in the module itself): Besides the main scope of this PR, I also renamed a few parameters in the `logs_storage` variable so it similar to the other modules that have an equivalent variable.

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)