### PR TITLE
feat: enable memcachedIndexWrites

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -26,6 +24,8 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -57,7 +57,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.3.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -212,7 +212,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.3.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.3.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -252,7 +252,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.3.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -59,7 +59,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.3.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -212,7 +212,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.3.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -60,7 +60,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.3.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -214,7 +214,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.3.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/locals.tf
+++ b/locals.tf
@@ -142,6 +142,9 @@ locals {
         memcachedIndexQueries = {
           enabled = true
         }
+        memcachedIndexWrites = {
+          enabled = true
+        }
         queryScheduler = {
           enabled  = true
           affinity = ""


### PR DESCRIPTION
## Description of the changes

Loki implements data caching at various levels. The fundamental caching mechanism employed presently is `memcached`. The Loki Module is currently equipped with three levels of caching configuration, and with the introduction of Loki version 2.8, the fourth level, known as memcachedIndexWrites, has been activated. This PR allows the utilization of the memcachedIndexWrites caching level.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [x] KinD partial test
- [ ] AKS (Azure)
- [x] EKS (AWS) partial test
- [ ] Scaleway
- [ ] SKS (Exoscale)