### PR TITLE
ci: add chart dependency upgrade workflow

### DIFF
--- a/.github/workflows/chart-upgrade.yaml
+++ b/.github/workflows/chart-upgrade.yaml
@@ -1,0 +1,48 @@
+---
+name: "chart-upgrade"
+
+on:
+  schedule:
+  - cron: "0 7 * * 1-5"
+  
+  workflow_dispatch:
+    inputs:
+      upgrade-strategy:
+        description: "Upgrade strategy to use. Valid values are 'major', 'minor' or 'patch'."
+        type: choice
+        options:
+        - "major"
+        - "minor"
+        - "patch"
+        required: true
+      excluded-dependencies:
+        description: "Comma-separated list of dependencies to exclude from upgrade (i.e. 'dependency1,dependency2,dependency3')."
+        type: string
+        required: false
+        default: ""
+      dry-run:
+        description: "Whether to run the upgrade in dry-run mode or not."
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+
+  chart-upgrade-schedule:
+    if: github.event_name == 'schedule'
+    strategy:
+      matrix:
+        upgrade-strategy: ["major", "minor"]
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-upgrade.yaml@main
+    with:
+      upgrade-strategy: ${{ matrix.upgrade-strategy }}
+      excluded-dependencies: ${{ inputs.excluded-dependencies }}
+      dry-run: ${{ inputs.dry-run }}
+
+  chart-upgrade-manual:
+    if: github.event_name == 'workflow_dispatch'
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-upgrade.yaml@main
+    with:
+      upgrade-strategy: ${{ inputs.upgrade-strategy }}
+      excluded-dependencies: ${{ inputs.excluded-dependencies }}
+      dry-run: ${{ inputs.dry-run }}

--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -24,8 +26,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -180,8 +180,8 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |===
 
 = Resources


### PR DESCRIPTION
## Description of the changes

This PR is for testing if the auto upgrade of helm charts works correctly.

## Breaking change

- [x] No