### PR TITLE
feat!: add support to oboukili/argocd v5

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> (>= 1)
 
@@ -17,15 +17,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -57,7 +57,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -165,7 +165,7 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> |>= 1
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_random]] <<requirement_random,random>> |>= 3
@@ -181,7 +181,7 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
 = Resources
@@ -212,7 +212,7 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> (>= 1)
 
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -185,7 +185,7 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> |>= 1
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_random]] <<requirement_random,random>> |>= 3
@@ -252,7 +252,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> (>= 1)
 
@@ -59,7 +59,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -167,7 +167,7 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> |>= 1
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_random]] <<requirement_random,random>> |>= 3
@@ -212,7 +212,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -3,7 +3,7 @@
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> (>= 1)
 
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -169,7 +169,7 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> |>= 1
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_random]] <<requirement_random,random>> |>= 3
@@ -216,7 +216,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/main.tf
+++ b/main.tf
@@ -76,14 +76,19 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = var.app_autosync
+      automated {
+        prune       = var.app_autosync.prune
+        self_heal   = var.app_autosync.self_heal
+        allow_empty = var.app_autosync.allow_empty
+      }
 
       retry {
-        backoff = {
-          duration     = ""
-          max_duration = ""
+        backoff {
+          duration     = "20s"
+          max_duration = "2m"
+          factor       = "2"
         }
-        limit = "0"
+        limit = "5"
       }
 
       sync_options = [

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -99,7 +99,7 @@ This module requires a Persistent Volume so it needs to be deployed after the mo
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> (>= 1)
 
@@ -162,7 +162,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -276,7 +276,7 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> |>= 1
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_random]] <<requirement_random,random>> |>= 3
@@ -328,7 +328,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source  = "oboukili/argocd"
-      version = ">= 4"
+      version = ">= 5"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

Adapt the module to be compatible with ArgoCD versions >= 5.x (in counterpart, it now incompatible with previous versions of the provider). 
This change to the provider is needed to work with ArgoCD 2.7.x

## Breaking change

- [ ] No
- [ ] Yes (in the Helm chart(s))
- [x] Yes (in the module itself): _the module is no longer compatible with argocd provider versions < 5.x_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [x] SKS (Exoscale)