### PR TITLE
fix: use more generic tolerations for promtail

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,15 +22,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
-
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -182,11 +182,11 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/locals.tf
+++ b/locals.tf
@@ -157,6 +157,12 @@ locals {
         }
       }
       promtail = {
+        tolerations = [
+          {
+            operator = "Exists"
+            effect   = "NoSchedule"
+          }
+        ]
         config = {
           clients = [{
             url = "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push"

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -12,9 +12,6 @@ locals {
         }
       }
     }
-    promtail = {
-      tolerations = local.promtail_tolerations
-    }
     } : null, var.distributed_mode ? null : {
     loki_stack = {
       loki = {
@@ -71,15 +68,4 @@ locals {
     working_directory = "/data/compactor"
     shared_store      = "s3"
   }
-
-  # These tolerations allow the pods to be scheduled on the router nodepool, otherwise we wouldn't be able to collect 
-  # the Traefik logs, since that nodepool is tainted and exclusively used for those pods.
-  promtail_tolerations = [
-    {
-      key      = "nodepool"
-      operator = "Equal"
-      value    = "router"
-      effect   = "NoSchedule"
-    },
-  ]
 }


### PR DESCRIPTION
## Description of the changes

Adding taints to your nodes would mean having to add tolerations to Promtail, since this application is required to be deployed on all nodes to receive the logs and send them to Loki.

Before, we only added a specific toleration on the SKS variant to allow Promtail to be deployed on the router nodes, but I've since considered it better to have a more generic toleration, similar to the one from Prometheus Node Exporter DaemonSet. I did not find it necessary to variabilize these tolerations any further.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)