### PR TITLE
fix/ci: fix autosync deactivation and correct chart auto-updater workflow

### DIFF
--- a/.github/workflows/chart-update.yaml
+++ b/.github/workflows/chart-update.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       update-strategy:
-        description: "update strategy to use. Valid values are 'patch', 'minor' or 'major'"
+        description: "Update strategy to use. Valid values are 'patch', 'minor' or 'major'"
         type: choice
         options:
         - "patch"

--- a/README.adoc
+++ b/README.adoc
@@ -22,15 +22,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
 
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -62,7 +62,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -217,7 +217,7 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -252,7 +252,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -59,7 +59,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -212,7 +212,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -216,7 +216,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/main.tf
+++ b/main.tf
@@ -76,10 +76,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -162,7 +162,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -328,7 +328,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>


### PR DESCRIPTION
## Description of the changes

This PR:
- re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #59. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.
- corrects a small typo on the auto-updater workflow.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] SKS (Exoscale)
- [x] KinD