### PR TITLE
feat: add variables to set AppProject, labels and destination cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -29,8 +31,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -56,13 +56,37 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.2"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -206,10 +230,28 @@ Description: Credentials to access the Loki ingress, if activated.
 |`"argocd"`
 |no
 
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.2"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -71,13 +71,37 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.2"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -241,10 +265,28 @@ object({
 |`"argocd"`
 |no
 
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.2"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -41,11 +41,13 @@ resource "azurerm_federated_identity_credential" "loki" {
 module "loki-stack" {
   source = "../"
 
-  argocd_namespace = var.argocd_namespace
-  target_revision  = var.target_revision
-  namespace        = var.namespace
-  app_autosync     = var.app_autosync
-  dependency_ids   = var.dependency_ids
+  argocd_namespace    = var.argocd_namespace
+  argocd_project      = var.argocd_project
+  destination_cluster = var.destination_cluster
+  target_revision     = var.target_revision
+  namespace           = var.namespace
+  app_autosync        = var.app_autosync
+  dependency_ids      = var.dependency_ids
 
   retention       = var.retention
   ingress         = var.ingress

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -43,6 +43,7 @@ module "loki-stack" {
 
   argocd_namespace    = var.argocd_namespace
   argocd_project      = var.argocd_project
+  argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster
   target_revision     = var.target_revision
   namespace           = var.namespace

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -53,13 +53,37 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.2"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -201,10 +225,28 @@ object({
 |`"argocd"`
 |no
 
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.2"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -3,6 +3,7 @@ module "loki-stack" {
 
   argocd_namespace    = var.argocd_namespace
   argocd_project      = var.argocd_project
+  argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster
   target_revision     = var.target_revision
   namespace           = var.namespace

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,11 +1,13 @@
 module "loki-stack" {
   source = "../"
 
-  argocd_namespace = var.argocd_namespace
-  target_revision  = var.target_revision
-  namespace        = var.namespace
-  app_autosync     = var.app_autosync
-  dependency_ids   = var.dependency_ids
+  argocd_namespace    = var.argocd_namespace
+  argocd_project      = var.argocd_project
+  destination_cluster = var.destination_cluster
+  target_revision     = var.target_revision
+  namespace           = var.namespace
+  app_autosync        = var.app_autosync
+  dependency_ids      = var.dependency_ids
 
   retention       = var.retention
   ingress         = var.ingress

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -55,13 +55,37 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.2"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -205,10 +229,28 @@ object({
 |`"argocd"`
 |no
 
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.2"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -3,6 +3,7 @@ module "loki-stack" {
 
   argocd_namespace    = var.argocd_namespace
   argocd_project      = var.argocd_project
+  argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster
   target_revision     = var.target_revision
   namespace           = var.namespace

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -1,11 +1,13 @@
 module "loki-stack" {
   source = "../"
 
-  argocd_namespace = var.argocd_namespace
-  target_revision  = var.target_revision
-  namespace        = var.namespace
-  app_autosync     = var.app_autosync
-  dependency_ids   = var.dependency_ids
+  argocd_namespace    = var.argocd_namespace
+  argocd_project      = var.argocd_project
+  destination_cluster = var.destination_cluster
+  target_revision     = var.target_revision
+  namespace           = var.namespace
+  app_autosync        = var.app_autosync
+  dependency_ids      = var.dependency_ids
 
   retention       = var.retention
   ingress         = var.ingress

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,10 @@ resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "loki-stack-${var.destination_cluster}" : "loki-stack"
     namespace = var.argocd_namespace
+    labels = merge({
+      "application" = "loki-stack"
+      "cluster"     = var.destination_cluster
+    }, var.argocd_labels)
   }
 
   timeouts {

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -14,8 +14,6 @@ module "loki-stack" {
   cluster_id       = module.sks.cluster_id
   argocd_namespace = module.argocd_bootstrap.argocd_namespace
 
-  distributed_mode = true
-
   logs_storage = {
     bucket_name = resource.aws_s3_bucket.this["loki"].id
     region      = resource.aws_s3_bucket.this["loki"].region
@@ -43,8 +41,6 @@ module "loki-stack" {
 
   cluster_id       = module.sks.cluster_id
   argocd_namespace = module.argocd_bootstrap.argocd_namespace
-
-  distributed_mode = true
 
   logs_storage = {
     bucket_name = resource.aws_s3_bucket.this["loki"].id

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -152,13 +152,37 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.2"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -313,10 +337,28 @@ object({
 |`"argocd"`
 |no
 
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.2"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -3,6 +3,7 @@ module "loki-stack" {
 
   argocd_namespace    = var.argocd_namespace
   argocd_project      = var.argocd_project
+  argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster
   target_revision     = var.target_revision
   namespace           = var.namespace

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,11 +1,13 @@
 module "loki-stack" {
   source = "../"
 
-  argocd_namespace = var.argocd_namespace
-  target_revision  = var.target_revision
-  namespace        = var.namespace
-  app_autosync     = var.app_autosync
-  dependency_ids   = var.dependency_ids
+  argocd_namespace    = var.argocd_namespace
+  argocd_project      = var.argocd_project
+  destination_cluster = var.destination_cluster
+  target_revision     = var.target_revision
+  namespace           = var.namespace
+  app_autosync        = var.app_autosync
+  dependency_ids      = var.dependency_ids
 
   retention       = var.retention
   ingress         = var.ingress

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,12 @@ variable "argocd_project" {
   default     = null
 }
 
+variable "argocd_labels" {
+  description = "Labels to attach to the Argo CD Application resource."
+  type        = map(string)
+  default     = {}
+}
+
 variable "destination_cluster" {
   description = "Destination cluster where the application should be deployed."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,18 @@ variable "argocd_namespace" {
   default     = "argocd"
 }
 
+variable "argocd_project" {
+  description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
+  type        = string
+  default     = null
+}
+
+variable "destination_cluster" {
+  description = "Destination cluster where the application should be deployed."
+  type        = string
+  default     = "in-cluster"
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR:
- Adds the required variables and configuration to allow the module to be deployed on a different cluster than Argo CD.
- Adds the possibility of placing the application inside a specified Argo CD project in order to avoid having a single project for each application throughout multiple clusters.
- Adds labels and a variable to add more labels to the Argo CD application to make it easier to sort applications on the web interface of Argo CD.
- Removes old variable from the example in the README.adoc of SKS.

**All these changes are made in preparation for having a centralized Argo CD that controls applications throughout multiple clusters.**

:warning: **Do a _Rebase and merge_.**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] EKS (AWS)
- [x] SKS (Exoscale)