### PR TITLE
fix!: remove the namespace variable, hardcode the Helm release name and other AKS changes 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,15 +22,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
 
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -47,14 +47,6 @@ The following resources are used by this module:
 === Optional Inputs
 
 The following input variables are optional (have default values):
-
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
 
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
@@ -86,15 +78,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"loki-stack"`
+Default: `"v6.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -190,11 +174,11 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -216,12 +200,6 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -243,13 +221,7 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"loki-stack"`
+|`"v6.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -34,9 +34,9 @@ Version:
 The following resources are used by this module:
 
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential[azurerm_federated_identity_credential.loki] (resource)
-- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.contributor] (resource)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.storage_contributor] (resource)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.loki] (resource)
-- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node] (data source)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] (data source)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] (data source)
 
 === Required Inputs
@@ -62,14 +62,6 @@ object({
 === Optional Inputs
 
 The following input variables are optional (have default values):
-
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
 
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
@@ -101,15 +93,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"loki-stack"`
+Default: `"v6.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -222,9 +206,9 @@ Description: Credentials to access the Loki ingress, if activated.
 |===
 |Name |Type
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential[azurerm_federated_identity_credential.loki] |resource
-|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.contributor] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.storage_contributor] |resource
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.loki] |resource
-|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] |data source
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] |data source
 |===
 
@@ -251,12 +235,6 @@ object({
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -278,13 +256,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"loki-stack"`
+|`"v6.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -9,12 +9,12 @@ variable "logs_storage" {
   })
 
   validation {
-    condition     = (var.logs_storage.managed_identity_node_rg_name == null) != (var.logs_storage.storage_account_key == null)
-    error_message = "You must set one (and only one) of these attributes: managed_identity_node_rg_name, storage_account_key."
+    condition     = (var.logs_storage.managed_identity_node_rg_name == null && var.logs_storage.managed_identity_oidc_issuer_url == null) != (var.logs_storage.storage_account_key == null)
+    error_message = "You can either set the variables for the managed identity or use storage account key, not both at the same time."
   }
 
   validation {
     condition     = (var.logs_storage.managed_identity_node_rg_name == null) == (var.logs_storage.managed_identity_oidc_issuer_url == null)
-    error_message = "managed_identity_node_rg_name & managed_identity_oidc_issuer_url are (un)set together."
+    error_message = "When using the managed identity, both `managed_identity_node_rg_name` and `managed_identity_oidc_issuer_url` are required."
   }
 }

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -10,11 +10,6 @@ locals {
       }
       } : null, {
       loki = merge(local.use_managed_identity ? {
-        # version >= 2.8 is required for workload identity support. Current chart version uses loki 2.7.5.
-        # TODO remove once chart uses a version >= 2.8.
-        image = {
-          tag = "2.8.0"
-        }
         podLabels = {
           "azure.workload.identity/use" = "true"
         }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_federated_identity_credential" "loki" {
   audience            = ["api://AzureADTokenExchange"]
   issuer              = var.logs_storage.managed_identity_oidc_issuer_url
   parent_id           = azurerm_user_assigned_identity.loki[0].id
-  subject             = "system:serviceaccount:${var.namespace}:loki" # "loki" is the fullnameOverride value
+  subject             = "system:serviceaccount:loki-stack:loki" # "loki" is the fullnameOverride value
 }
 
 module "loki-stack" {
@@ -46,7 +46,6 @@ module "loki-stack" {
   argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster
   target_revision     = var.target_revision
-  namespace           = var.namespace
   app_autosync        = var.app_autosync
   dependency_ids      = var.dependency_ids
 

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -41,7 +41,6 @@ resource "azurerm_federated_identity_credential" "loki" {
 module "loki-stack" {
   source = "../"
 
-  argocd_namespace    = var.argocd_namespace
   argocd_project      = var.argocd_project
   argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,4 +1,4 @@
-data "azurerm_resource_group" "node" {
+data "azurerm_resource_group" "node_resource_group" {
   count = local.use_managed_identity ? 1 : 0
 
   name = var.logs_storage.managed_identity_node_rg_name
@@ -14,12 +14,12 @@ data "azurerm_storage_container" "container" {
 resource "azurerm_user_assigned_identity" "loki" {
   count = local.use_managed_identity ? 1 : 0
 
-  resource_group_name = data.azurerm_resource_group.node[0].name
-  location            = data.azurerm_resource_group.node[0].location
   name                = "loki"
+  resource_group_name = data.azurerm_resource_group.node_resource_group[0].name
+  location            = data.azurerm_resource_group.node_resource_group[0].location
 }
 
-resource "azurerm_role_assignment" "contributor" {
+resource "azurerm_role_assignment" "storage_contributor" {
   count = local.use_managed_identity ? 1 : 0
 
   scope                = data.azurerm_storage_container.container[0].resource_manager_id
@@ -31,7 +31,7 @@ resource "azurerm_federated_identity_credential" "loki" {
   count = local.use_managed_identity ? 1 : 0
 
   name                = "loki"
-  resource_group_name = data.azurerm_resource_group.node[0].name
+  resource_group_name = data.azurerm_resource_group.node_resource_group[0].name
   audience            = ["api://AzureADTokenExchange"]
   issuer              = var.logs_storage.managed_identity_oidc_issuer_url
   parent_id           = azurerm_user_assigned_identity.loki[0].id

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -45,14 +45,6 @@ object({
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -83,15 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"loki-stack"`
+Default: `"v6.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -211,12 +195,6 @@ object({
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -238,13 +216,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"loki-stack"`
+|`"v6.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -6,7 +6,6 @@ module "loki-stack" {
   argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster
   target_revision     = var.target_revision
-  namespace           = var.namespace
   app_autosync        = var.app_autosync
   dependency_ids      = var.dependency_ids
 

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,7 +1,6 @@
 module "loki-stack" {
   source = "../"
 
-  argocd_namespace    = var.argocd_namespace
   argocd_project      = var.argocd_project
   argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -47,14 +47,6 @@ object({
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -85,15 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"loki-stack"`
+Default: `"v6.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -215,12 +199,6 @@ object({
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -242,13 +220,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"loki-stack"`
+|`"v6.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -6,7 +6,6 @@ module "loki-stack" {
   argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster
   target_revision     = var.target_revision
-  namespace           = var.namespace
   app_autosync        = var.app_autosync
   dependency_ids      = var.dependency_ids
 

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -1,7 +1,6 @@
 module "loki-stack" {
   source = "../"
 
-  argocd_namespace    = var.argocd_namespace
   argocd_project      = var.argocd_project
   argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster

--- a/locals.tf
+++ b/locals.tf
@@ -3,8 +3,8 @@ locals {
 
   helm_values = [{
     eventHandler = {
-      namespace       = var.namespace
-      lokiURL         = "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push"
+      namespace       = "loki-stack"
+      lokiURL         = "http://${local.fullnameOverride}-distributor.loki-stack:3100/loki/api/v1/push"
       labels          = {}
       grafanaAgentTag = "main-4f86002"
     }
@@ -15,7 +15,7 @@ locals {
       allowedIPs      = var.ingress.allowed_ips
       serviceName     = "${local.fullnameOverride}-query-frontend"
     } : null
-    datasourceURL = "http://${local.fullnameOverride}-query-frontend.${var.namespace}:3100"
+    datasourceURL = "http://${local.fullnameOverride}-query-frontend.loki-stack:3100"
     loki-distributed = {
       fullnameOverride = local.fullnameOverride
       compactor = {
@@ -160,7 +160,7 @@ locals {
       ]
       config = {
         clients = [{
-          url = "http://${local.fullnameOverride}-distributor.${var.namespace}:3100/loki/api/v1/push"
+          url = "http://${local.fullnameOverride}-distributor.loki-stack:3100/loki/api/v1/push"
         }]
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,8 @@ resource "argocd_application" "this" {
       path            = "charts/loki-microservice"
       target_revision = var.target_revision
       helm {
-        values = data.utils_deep_merge_yaml.values.output
+        release_name = "loki"
+        values       = data.utils_deep_merge_yaml.values.output
       }
     }
 

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,7 @@ resource "argocd_project" "this" {
 
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "loki-stack-${var.destination_cluster}" : "loki-stack"
-    namespace = var.argocd_namespace
-    annotations = {
-      "devops-stack.io/argocd_namespace" = var.argocd_namespace
-    }
+    namespace = "argocd"
   }
 
   spec {
@@ -50,7 +47,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "loki-stack-${var.destination_cluster}" : "loki-stack"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "loki-stack"
       "cluster"     = var.destination_cluster

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "argocd_project" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "loki-stack"
     }
 
     orphaned_resources {
@@ -78,7 +78,7 @@ resource "argocd_application" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "loki-stack"
     }
 
     sync_policy {

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -144,14 +144,6 @@ object({
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -182,15 +174,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"loki-stack"`
+Default: `"v6.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -323,12 +307,6 @@ object({
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -350,13 +328,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"loki-stack"`
+|`"v6.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -6,7 +6,6 @@ module "loki-stack" {
   argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster
   target_revision     = var.target_revision
-  namespace           = var.namespace
   app_autosync        = var.app_autosync
   dependency_ids      = var.dependency_ids
 

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,7 +1,6 @@
 module "loki-stack" {
   source = "../"
 
-  argocd_namespace    = var.argocd_namespace
   argocd_project      = var.argocd_project
   argocd_labels       = var.argocd_labels
   destination_cluster = var.destination_cluster

--- a/variables.tf
+++ b/variables.tf
@@ -2,12 +2,6 @@
 ## Standard variables
 #######################
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-  default     = "argocd"
-}
-
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -32,12 +32,6 @@ variable "target_revision" {
   default     = "v6.0.0" # x-release-please-version
 }
 
-variable "namespace" {
-  description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
-  type        = string
-  default     = "loki-stack"
-}
-
 variable "helm_values" {
   description = "Helm chart value overrides. They should be passed as a list of HCL structures."
   type        = any


### PR DESCRIPTION
## Description of the changes

The main changes of this PR are the following:

- **fix!: hardcode the release name to remove the destination cluster**

  I found out that Argo CD passes the name of the application as a value to set the Helm chart. This means that all the templating that used `{ $.Release.Name }` would resolve to the name given to Argo CD application.

  In a multicluster deployment, using a single Argo CD, the names of the applications must be different. We solved that by appending the cluster name to the default application name when deploying on different clusters than `in-cluster`. However, this resulted in multiple problems for deployments that depended on the name of the application being static, so this solves that.

  This is a breaking change because sometimes this requires an application to be deleted and recreated.

- **fix!: remove the namespace variable**

  We found out that on multiple modules we were referencing resources from other modules using their default namespaces and this was hardcoded. In case someone decided to change the namespace of deployment of a certain application, this could break the way modules work with each other.

  We've decided that in order to avoid undefined behaviors caused by overloading this variable, it would be best to remove it entirely.

- **fix!: remove the ArgoCD namespace variable**

  Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

- **fix(aks): remove image tag because chart has been upgraded**

  I noticed the chart had been upgraded, so we no longer need to hardcode the image tag of the application, because the chart supports workload identities.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): because of the removal of the `namespace` and `argocd_namespace` variables and the fact that overloading the release name can force a recreation of the application.

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)