### PR TITLE
fix(aks): add dependencies to fix reading of storage account

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -29,8 +31,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -78,7 +78,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v7.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -221,7 +221,7 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v7.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -17,6 +17,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_azurerm]] <<provider_azurerm,azurerm>>
 
 === Modules
@@ -36,6 +38,7 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential[azurerm_federated_identity_credential.loki] (resource)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.storage_contributor] (resource)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.loki] (resource)
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] (resource)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] (data source)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] (data source)
 
@@ -93,7 +96,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v7.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -189,6 +192,7 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_azurerm]] <<provider_azurerm,azurerm>> |n/a
 |===
 
@@ -208,6 +212,7 @@ Description: Credentials to access the Loki ingress, if activated.
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential[azurerm_federated_identity_credential.loki] |resource
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.storage_contributor] |resource
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.loki] |resource
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] |resource
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] |data source
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] |data source
 |===
@@ -256,7 +261,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v7.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,7 +1,17 @@
+# This null_resource is required otherwise Terraform would try to read the resource group data and/or the storage 
+# account even if they were not created yet. 
+resource "null_resource" "dependencies" {
+  triggers = var.dependency_ids
+}
+
 data "azurerm_resource_group" "node_resource_group" {
   count = local.use_managed_identity ? 1 : 0
 
   name = var.logs_storage.managed_identity_node_rg_name
+
+  depends_on = [
+    resource.null_resource.dependencies
+  ]
 }
 
 data "azurerm_storage_container" "container" {
@@ -9,6 +19,10 @@ data "azurerm_storage_container" "container" {
 
   name                 = var.logs_storage.container
   storage_account_name = var.logs_storage.storage_account
+
+  depends_on = [
+    resource.null_resource.dependencies
+  ]
 }
 
 resource "azurerm_user_assigned_identity" "loki" {

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v7.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -216,7 +216,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v7.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v7.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -220,7 +220,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v7.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -174,7 +174,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v7.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -328,7 +328,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v7.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>


### PR DESCRIPTION
## Description of the changes

Terraform is capable of deducting the Storage Account name and Resource Group name right away although the resources have yet been created. This means that the `data` resources on the `main.tf` try to reach resources which do not yet exist and this breaks the first deployment. I've added a `null_resource` to avoid this breakage.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)