### PR TITLE
feat(eks)!: add option to create IAM role for the metrics storage

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
@@ -29,8 +31,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -78,7 +78,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.1.0"`
+Default: `"v7.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -333,11 +333,11 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -380,7 +380,7 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.1.0"`
+|`"v7.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -96,7 +96,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.1.0"`
+Default: `"v7.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -420,7 +420,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.1.0"`
+|`"v7.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -10,7 +10,7 @@ variable "logs_storage" {
 
   validation {
     condition     = (var.logs_storage.managed_identity_node_rg_name == null && var.logs_storage.managed_identity_oidc_issuer_url == null) != (var.logs_storage.storage_account_key == null)
-    error_message = "You can either set the variables for the managed identity or use storage account key, not both at the same time."
+    error_message = "You can either set the variables for the managed identity or use a storage account key, not both at the same time."
   }
 
   validation {

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -13,15 +13,35 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
+=== Providers
+
+The following providers are used by this module:
+
+- [[provider_aws]] <<provider_aws,aws>>
+
 === Modules
 
 The following Modules are called:
+
+==== [[module_iam_assumable_role_loki]] <<module_iam_assumable_role_loki,iam_assumable_role_loki>>
+
+Source: terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc
+
+Version: ~> 5.0
 
 ==== [[module_loki-stack]] <<module_loki-stack,loki-stack>>
 
 Source: ../
 
 Version:
+
+=== Resources
+
+The following resources are used by this module:
+
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy[aws_iam_policy.loki] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document[aws_iam_policy_document.loki] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket[aws_s3_bucket.loki] (data source)
 
 === Required Inputs
 
@@ -31,13 +51,16 @@ The following input variables are required:
 
 Description: AWS S3 bucket configuration values for the bucket where the logs will be stored.
 
+An IAM role is required to give the Loki components read and write access to the S3 bucket. You can create this role yourself or let the module create it for you. If you want the module to create the role, you need to provide the OIDC issuer's URL for the EKS cluster. If you create the role yourself, you need to provide the ARN of the IAM role you created.
+
 Type:
 [source,hcl]
 ----
 object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
 ----
 
@@ -75,7 +98,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.1.0"`
+Default: `"v7.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -325,12 +348,31 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
+= Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_aws]] <<provider_aws,aws>> |n/a
+|===
+
 = Modules
 
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
+|[[module_iam_assumable_role_loki]] <<module_iam_assumable_role_loki,iam_assumable_role_loki>> |terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc |~> 5.0
 |[[module_loki-stack]] <<module_loki-stack,loki-stack>> |../ |
+|===
+
+= Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy[aws_iam_policy.loki] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document[aws_iam_policy_document.loki] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket[aws_s3_bucket.loki] |data source
 |===
 
 = Inputs
@@ -340,14 +382,18 @@ Description: Credentials to access the Loki ingress, if activated.
 |Name |Description |Type |Default |Required
 |[[input_logs_storage]] <<input_logs_storage,logs_storage>>
 |AWS S3 bucket configuration values for the bucket where the logs will be stored.
+
+An IAM role is required to give the Loki components read and write access to the S3 bucket. You can create this role yourself or let the module create it for you. If you want the module to create the role, you need to provide the OIDC issuer's URL for the EKS cluster. If you create the role yourself, you need to provide the ARN of the IAM role you created.
+
 |
 
 [source]
 ----
 object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
 ----
 
@@ -375,7 +421,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.1.0"`
+|`"v7.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/eks/extra-variables.tf
+++ b/eks/extra-variables.tf
@@ -1,8 +1,18 @@
 variable "logs_storage" {
-  description = "AWS S3 bucket configuration values for the bucket where the logs will be stored."
+  description = <<-EOT
+    AWS S3 bucket configuration values for the bucket where the logs will be stored.
+
+    An IAM role is required to give the Loki components read and write access to the S3 bucket. You can create this role yourself or let the module create it for you. If you want the module to create the role, you need to provide the OIDC issuer's URL for the EKS cluster. If you create the role yourself, you need to provide the ARN of the IAM role you created.
+  EOT
   type = object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
+
+  validation {
+    condition     = var.logs_storage.create_role ? var.logs_storage.cluster_oidc_issuer_url != null : var.logs_storage.iam_role_arn != null
+    error_message = "If you want to create a role, you need to provide the OIDC issuer's URL for the EKS cluster. Otherwise, you need to provide the ARN of the IAM role you created."
+  }
 }

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,4 +1,6 @@
 locals {
+  iam_role_arn = var.logs_storage.create_role ? module.iam_assumable_role_loki.iam_role_arn : var.logs_storage.iam_role_arn
+
   helm_values = [{
     loki-distributed = {
       loki = {
@@ -16,7 +18,7 @@ locals {
         }
         storageConfig = {
           aws = {
-            s3 = "s3://${var.logs_storage.region}/${var.logs_storage.bucket_id}"
+            s3 = "s3://${data.aws_s3_bucket.loki.region}/${data.aws_s3_bucket.loki.id}"
           }
           boltdb_shipper = {
             shared_store = "s3"
@@ -32,7 +34,7 @@ locals {
       serviceAccount = {
         create = true
         annotations = {
-          "eks.amazonaws.com/role-arn" = var.logs_storage.iam_role_arn
+          "eks.amazonaws.com/role-arn" = local.iam_role_arn
         }
       }
     }

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,3 +1,51 @@
+data "aws_s3_bucket" "loki" {
+  bucket = var.logs_storage.bucket_id
+}
+
+# As per https://grafana.com/docs/loki/latest/operations/storage/#s3
+data "aws_iam_policy_document" "loki" {
+  count = var.logs_storage.create_role ? 1 : 0
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      data.aws_s3_bucket.loki.arn,
+      format("%s/*", data.aws_s3_bucket.loki.arn),
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "loki" {
+  count = var.logs_storage.create_role ? 1 : 0
+
+  name_prefix = "loki-s3-"
+  description = "Loki IAM policy for accessing the S3 bucket named ${data.aws_s3_bucket.loki.id}"
+  policy      = data.aws_iam_policy_document.loki[0].json
+}
+
+module "iam_assumable_role_loki" {
+  source                     = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                    = "~> 5.0"
+  create_role                = var.logs_storage.create_role
+  number_of_role_policy_arns = 1
+  role_name_prefix           = "loki-s3-"
+  provider_url               = var.logs_storage.create_role ? trimprefix(var.logs_storage.cluster_oidc_issuer_url, "https://") : ""
+  role_policy_arns           = [var.logs_storage.create_role ? resource.aws_iam_policy.loki[0].arn : null]
+
+  # List of ServiceAccounts that have permission to attach to this IAM role
+  oidc_fully_qualified_subjects = [
+    "system:serviceaccount:loki-stack:loki",
+  ]
+}
+
 module "loki-stack" {
   source = "../"
 

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.1.0"`
+Default: `"v7.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -379,7 +379,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.1.0"`
+|`"v7.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -174,7 +174,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.1.0"`
+Default: `"v7.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -487,7 +487,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.1.0"`
+|`"v7.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>


### PR DESCRIPTION
## Description of the changes

This commit solves ISDEVOPS-279 and ISDEVOPS-283 for the EKS variant. That is, it adds support for creating the IAM role automatically inside the modules while also giving the chance to provide a custom one managed by the user.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes - because the Terraform variable was changed

## Tests executed on which distribution(s)

- [x] EKS (AWS)