### PR TITLE
docs: remove old charts from the README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,5 @@
-:loki-stack-chart-version: 2.8.9
 :loki-distributed-chart-version: 0.79.1
 :promtail-chart-version: 6.16.3
-:filebeat-chart-version: 7.17.3
 
 // BEGIN_TF_DOCS
 === Requirements

--- a/README.adoc
+++ b/README.adoc
@@ -331,11 +331,11 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources


### PR DESCRIPTION
## Description of the changes

This is just a cleanup that was forgotten when we depreciated the charts for `filebeat` and `loki-stack`.

## Breaking change

- [x] No