### PR TITLE
feat!: remove the cluster_id variable || fix: remove the working_directory attribute in the compactor config 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,15 +22,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_htpasswd]] <<provider_htpasswd,htpasswd>> (>= 1)
 
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -78,7 +78,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -335,8 +335,8 @@ Description: Credentials to access the Loki ingress, if activated.
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
@@ -380,7 +380,7 @@ Description: Credentials to access the Loki ingress, if activated.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/README.adoc
+++ b/README.adoc
@@ -335,8 +335,8 @@ Description: Credentials to access the Loki ingress, if activated.
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_htpasswd]] <<provider_htpasswd,htpasswd>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
 |===
 

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -96,7 +96,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -420,7 +420,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -50,8 +50,7 @@ locals {
         }
         structuredConfig = {
           compactor = {
-            shared_store      = "azure"
-            working_directory = "/var/loki"
+            shared_store = "azure"
           }
         }
       })

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -98,7 +98,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -421,7 +421,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -26,8 +26,7 @@ locals {
         }
         structuredConfig = {
           compactor = {
-            working_directory = "/data/compactor"
-            shared_store      = "s3"
+            shared_store = "s3"
           }
         }
       }

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -77,7 +77,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -379,7 +379,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/kind/locals.tf
+++ b/kind/locals.tf
@@ -30,8 +30,7 @@ locals {
         }
         structuredConfig = {
           compactor = {
-            working_directory = "/data/compactor"
-            shared_store      = "aws"
+            shared_store = "aws"
           }
         }
       }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -119,12 +119,6 @@ Version:
 
 The following input variables are required:
 
-==== [[input_cluster_id]] <<input_cluster_id,cluster_id>>
-
-Description: ID of the SKS cluster.
-
-Type: `string`
-
 ==== [[input_logs_storage]] <<input_logs_storage,logs_storage>>
 
 Description: Exoscale SOS bucket configuration values for the bucket where the logs will be stored.
@@ -174,7 +168,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -443,12 +437,6 @@ Description: Credentials to access the Loki ingress, if activated.
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_cluster_id]] <<input_cluster_id,cluster_id>>
-|ID of the SKS cluster.
-|`string`
-|n/a
-|yes
-
 |[[input_logs_storage]] <<input_logs_storage,logs_storage>>
 |Exoscale SOS bucket configuration values for the bucket where the logs will be stored.
 |
@@ -487,7 +475,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/sks/extra-variables.tf
+++ b/sks/extra-variables.tf
@@ -1,8 +1,3 @@
-variable "cluster_id" {
-  description = "ID of the SKS cluster."
-  type        = string
-}
-
 variable "logs_storage" {
   description = "Exoscale SOS bucket configuration values for the bucket where the logs will be stored."
   type = object({

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -1,9 +1,6 @@
 locals {
   helm_values = [{
     loki-distributed = {
-      global = {
-        clusterDomain = "${var.cluster_id}.cluster.local"
-      }
       loki = {
         schemaConfig = {
           configs = [{

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -29,8 +29,7 @@ locals {
         }
         structuredConfig = {
           compactor = {
-            working_directory = "/data/compactor"
-            shared_store      = "s3"
+            shared_store = "s3"
           }
         }
       }


### PR DESCRIPTION
## Description of the changes

When creating an SKS cluster, Exoscale used to provision a cluster domain value of `<CLUSTER_ID>.cluster.local`. This is the legacy value for SKS cluster domain.

They recently transitioned to provisioning SKS cluster with the default cluster domain value of `cluster.local`.

Consequently, we need to remove the adaptations on our modules that were there to support this bizarre, and now legacy, behavior.

I also fixed a problem we had in the SKS, EKS and KinD configurations that was preventing `loki-compactor` from being correctly deployed from the v8.2.0 version of the module -> see [this commit message](https://github.com/camptocamp/devops-stack-module-loki-stack/pull/119/commits/acd71bad759dc7bb47209ef70934780055c7bb3a) for further explanations.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): the variable `cluster_id` was removed from the SKS variant

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)
- [x] EKS (AWS)
